### PR TITLE
Remove trailing space from link

### DIFF
--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -149,8 +149,7 @@ useSeoAnalysis(identifyAnalysis, {
               class="underline"
               :to="`https://api.github.com/users/${username}/events?per_page=100`"
             >
-              events
-            </NuxtLink>
+              events</NuxtLink>
             from this account
           </p>
         </div>


### PR DESCRIPTION
Currently, https://agentscan.netlify.app/user/octocat renders as:
<img width="1212" height="612" alt="image" src="https://github.com/user-attachments/assets/f7bc9e45-d7c0-4c8f-84b1-3716e88a1c3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustment with no visible user impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->