### PR TITLE
Use checkout v6

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/agent-scan
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This addresses the warning in https://github.com/MatteoGabriele/agentscan/actions/runs/22955455537

Annotations
1 warning
[check-pr](https://github.com/MatteoGabriele/agentscan/actions/runs/22955455537/job/66630851493#step:7:2)
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment infrastructure dependencies to maintain system reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->