### PR TITLE
feat: improve scatter chart config

### DIFF
--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -1,0 +1,77 @@
+import { computed, type ComputedRef, type Ref, unref } from "vue";
+import { useSupported } from "@vueuse/core";
+
+type CssVariableSource =
+  | HTMLElement
+  | null
+  | undefined
+  | Ref<HTMLElement | null | undefined>;
+
+type UseCssVariableOptions = {
+  element?: CssVariableSource;
+};
+
+function readCssVariable(element: HTMLElement, variableName: string): string {
+  return getComputedStyle(element).getPropertyValue(variableName).trim();
+}
+
+function toCamelCase(cssVariable: string): string {
+  return cssVariable
+    .replace(/^--/, "")
+    .replace(/-([a-z0-9])/gi, (_, c) => c.toUpperCase());
+}
+
+function resolveElement(element?: CssVariableSource): HTMLElement | null {
+  if (typeof window === "undefined" || typeof document === "undefined")
+    return null;
+  if (!element) return document.documentElement;
+  const resolved = unref(element);
+  return resolved ?? document.documentElement;
+}
+
+/**
+ * Read multiple CSS custom properties at once and expose them as a reactive object.
+ *
+ * Each CSS variable name is normalized into a camelCase key:
+ * - Leading `--` is removed
+ * - kebab-case is converted to camelCase
+ *
+ * Example:
+ * ```ts
+ * useCssVariables(['--bg', '--fg-subtle'])
+ * // => colors.value = { bg: '...', fgSubtle: '...' }
+ * ```
+ *
+ * The returned values are always resolved via `getComputedStyle`, meaning the
+ * effective value is returned (after cascade, theme classes, etc.).
+ *
+ * Reactivity behavior:
+ * - Updates automatically when the observed element changes
+ * - Can react to theme toggles via `watchHtmlAttributes`
+ * - Can react to responsive CSS variables via `watchResize`
+ *
+ * @param variables - List of CSS variable names (must include the leading `--`)
+ * @param options - Configuration options
+ * @param options.element - Element to read variables from (defaults to `:root`)
+ *
+ * @returns An object containing a reactive `colors` map, keyed by camelCase names
+ */
+export function useCssVariables(
+  variables: readonly string[],
+  options: UseCssVariableOptions = {},
+): { colors: ComputedRef<Record<string, string>> } {
+  const elementComputed = computed(() => resolveElement(options.element));
+
+  const colors = computed<Record<string, string>>(() => {
+    const element = elementComputed.value;
+    if (!element) return {};
+
+    const result: Record<string, string> = {};
+    for (const variable of variables) {
+      result[toCamelCase(variable)] = readCssVariable(element, variable);
+    }
+    return result;
+  });
+
+  return { colors };
+}

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -10,25 +10,36 @@ import "vue-data-ui/style.css";
 
 const { data, status, error } = useScan();
 
-const { colors } = useCssVariables([
-  "--bg",
-  "--card",
-  "--border",
-  "--border-light",
-  "--text",
-  "--text-muted",
-  "--blue",
-  "--green",
-  "--green-hover",
-  "--text-green",
-  "--green-bg",
-  "--danger",
-  "--danger-hover",
-  "--danger-bg",
-  "--red",
-  "--red-hover",
-  "--red-bg",
-]);
+const rootEl = shallowRef<HTMLElement | null>(null);
+
+onMounted(async () => {
+  rootEl.value = document.documentElement;
+});
+
+const { colors } = useCssVariables(
+  [
+    "--bg",
+    "--card",
+    "--border",
+    "--border-light",
+    "--text",
+    "--text-muted",
+    "--blue",
+    "--green",
+    "--green-hover",
+    "--text-green",
+    "--green-bg",
+    "--danger",
+    "--danger-hover",
+    "--danger-bg",
+    "--red",
+    "--red-hover",
+    "--red-bg",
+  ],
+  {
+    element: rootEl,
+  },
+);
 
 console.log(colors.value);
 

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -10,6 +10,28 @@ import "vue-data-ui/style.css";
 
 const { data, status, error } = useScan();
 
+const { colors } = useCssVariables([
+  "--bg",
+  "--card",
+  "--border",
+  "--border-light",
+  "--text",
+  "--text-muted",
+  "--blue",
+  "--green",
+  "--green-hover",
+  "--text-green",
+  "--green-bg",
+  "--danger",
+  "--danger-hover",
+  "--danger-bg",
+  "--red",
+  "--red-hover",
+  "--red-bg",
+]);
+
+console.log(colors.value);
+
 definePageMeta({
   layout: false,
 });
@@ -47,22 +69,22 @@ const dataset = computed<VueUiScatterDatasetItem[]>(() => {
       dataset: data.value ?? [],
       min: 0,
       max: 50,
-      color: "red",
-      name: "automated",
+      color: colors.value.redHover!,
+      name: "automated (0 - 50)",
     }),
     ...convertToScatterCluster({
       dataset: data.value ?? [],
       min: 51,
       max: 70,
-      color: "orange",
-      name: "mixed",
+      color: colors.value.dangerHover!,
+      name: "mixed (50 - 70)",
     }),
     ...convertToScatterCluster({
       dataset: data.value ?? [],
       min: 71,
       max: 101,
-      color: "green",
-      name: "organic",
+      color: colors.value.greenHover!,
+      name: "organic (70 - 100)",
     }),
   ];
 });
@@ -77,19 +99,30 @@ const averageScore = computed(() => {
 
 const config = computed<VueUiScatterConfig>(() => {
   return {
-    userOptions: { show: false },
+    userOptions: {
+      show: false,
+      useCursorPointer: true,
+    },
     style: {
       backgroundColor: "transparent",
-      legend: { show: true },
+      legend: {
+        show: true,
+        backgroundColor: "transparent",
+        color: colors.value.textMuted,
+      },
       tooltip: { show: false },
       title: {
         text: `Average score: ${Math.round(averageScore.value)}`,
+        bold: false,
+        color: colors.value.text,
       },
       layout: {
+        height: 300,
         plots: {
           radius: 3,
           opacity: 1,
           opacityNotSelected: 1,
+          stroke: colors.value.bg,
           giftWrap: {
             show: true,
           },
@@ -105,21 +138,34 @@ const config = computed<VueUiScatterConfig>(() => {
         axis: {
           xMin: 0,
           xMax: 100,
+          stroke: colors.value.borderLight,
         },
         dataLabels: {
           reverseAxisLabels: true,
           xAxis: {
+            offsetY: -20,
             showValue: false,
             name: "score",
+            color: colors.value.textMuted,
             scales: {
               show: true,
+              steps: 2,
+              labels: {
+                color: colors.value.textMuted,
+              },
             },
           },
           yAxis: {
             name: "event count",
+            offsetX: 28,
             showValue: false,
+            color: colors.value.textMuted,
             scales: {
               show: true,
+              steps: 2,
+              labels: {
+                color: colors.value.textMuted,
+              },
             },
           },
         },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,6 +11,7 @@ export default defineNuxtConfig({
         "dayjs", // CJS
         "@unveil/identity",
         "@vueuse/core",
+        "vue-data-ui/vue-ui-scatter",
       ],
     },
   },


### PR DESCRIPTION
This improves the chart configuration to have a more minimalist layout.
I'm using also a simplified version of the composable we have on npmx to use css colors in the script.