### PR TITLE
fix: tweak chart config

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -77,3 +77,9 @@ body {
   color: var(--text);
   min-height: 100vh;
 }
+
+@media screen and (min-width: 768px) {
+  .vue-data-ui-tooltip {
+    margin-left: 130px !important;
+  }
+}

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -248,11 +248,3 @@ const config = computed<VueUiStacklineConfig>(() => {
     <VueUiStackline v-if="hasEnoughDays" :dataset="dataset" :config="config" />
   </ClientOnly>
 </template>
-
-<style>
-@media screen and (min-width: 768px) {
-  .vue-data-ui-tooltip {
-    margin-left: 130px !important;
-  }
-}
-</style>

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -4,7 +4,7 @@ import {
   type VueUiStacklineDatasetItem,
   type VueUiStacklineConfig,
 } from "vue-data-ui/vue-ui-stackline";
-import { getCompleteHourRange } from "./chart";
+import { getCompleteDayRange } from "./chart";
 import type { GitHubEvent, GitHubEventType } from "~~/shared/types/identity";
 import { githubEventTypes } from "~~/shared/types/identity";
 import "vue-data-ui/style.css";
@@ -17,7 +17,7 @@ const props = defineProps<{
 
 const rootEl = shallowRef<HTMLElement | null>(null);
 
-onMounted(() => {
+onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
@@ -106,60 +106,23 @@ function isGitHubEventType(type: string | null): type is GitHubEventType {
   return type !== null && githubEventTypes.includes(type as GitHubEventType);
 }
 
-const eventTimestamps = computed<number[]>(() => {
-  return props.events
-    .filter((event) => event.created_at && isGitHubEventType(event.type))
-    .map((event) => new Date(event.created_at!).getTime())
-    .filter((timestamp) => !Number.isNaN(timestamp));
-});
-
-const totalDays = computed<number>(() => {
-  if (!eventTimestamps.value.length) {
-    return 0;
-  }
-
-  const firstTimestamp = Math.min(...eventTimestamps.value);
-  const lastTimestamp = Math.max(...eventTimestamps.value);
-  const oneDay = 24 * 60 * 60 * 1000;
-
-  return Math.ceil((lastTimestamp - firstTimestamp) / oneDay);
-});
-
-const chunkHours = computed<number>(() => {
-  return totalDays.value < 4 ? 1 : 6;
-});
-
-function getEventHourKey(createdAt: string): string {
-  const date = new Date(createdAt);
-  const bucketHour =
-    Math.floor(date.getUTCHours() / chunkHours.value) * chunkHours.value;
-
-  date.setUTCHours(bucketHour, 0, 0, 0);
-
-  return date.toISOString();
-}
-
-const eventHours = computed<string[]>(() => {
+const eventDays = computed(() => {
   return Array.from(
     new Set(
       props.events
         .filter((event) => event.created_at && isGitHubEventType(event.type))
-        .map((event) => getEventHourKey(event.created_at!)),
+        .map((event) => event.created_at!.slice(0, 10)),
     ),
   ).sort();
 });
 
-const completeHours = computed<string[]>(() => {
-  return getCompleteHourRange(eventHours.value, chunkHours.value);
-});
-
-const hasEnoughHours = computed<boolean>(() => {
-  return completeHours.value.length > 1;
-});
+const hasEnoughDays = computed<boolean>(() => eventDays.value.length > 1);
 
 function createStacklineDataset(
   events: GitHubEvent[],
 ): VueUiStacklineDatasetItem[] {
+  const days = getCompleteDayRange(eventDays.value);
+
   const counts: Record<GitHubEventType, Record<string, number>> = {
     PullRequestEvent: {},
     CreateEvent: {},
@@ -170,14 +133,16 @@ function createStacklineDataset(
     if (!event.created_at || !isGitHubEventType(event.type)) {
       continue;
     }
-    const hour = getEventHourKey(event.created_at);
-    counts[event.type][hour] = (counts[event.type][hour] || 0) + 1;
+
+    const day = event.created_at.slice(0, 10);
+
+    counts[event.type][day] = (counts[event.type][day] || 0) + 1;
   }
 
   return githubEventTypes.map((eventType) => ({
     name: eventConfig.value[eventType].name,
     color: eventConfig.value[eventType].color,
-    series: completeHours.value.map((hour) => counts[eventType][hour] || 0),
+    series: days.map((day) => counts[eventType][day] || 0),
   }));
 }
 
@@ -186,9 +151,12 @@ const dataset = computed<VueUiStacklineDatasetItem[]>(() => {
 });
 
 const timestamps = computed<number[]>(() => {
-  return completeHours.value.map((hour) => new Date(hour).getTime());
+  return getCompleteDayRange(eventDays.value).map((day) =>
+    new Date(day).getTime(),
+  );
 });
 
+// true: show as percentages
 const isDistributed = shallowRef(false);
 
 const config = computed<VueUiStacklineConfig>(() => {
@@ -197,7 +165,6 @@ const config = computed<VueUiStacklineConfig>(() => {
     style: {
       chart: {
         backgroundColor: "transparent",
-        color: colors.value.textMuted,
         grid: {
           x: {
             axisColor: colors.value.border,
@@ -218,7 +185,6 @@ const config = computed<VueUiStacklineConfig>(() => {
                   year: "dd MMM",
                   month: "dd MMM",
                   day: "dd MMM",
-                  hour: "dd MMM",
                   minute: "dd MMM",
                   second: "dd MMM",
                 },
@@ -257,12 +223,10 @@ const config = computed<VueUiStacklineConfig>(() => {
           },
         },
         padding: {
-          left: 52,
-          right: 52,
+          left: 48,
+          right: 48,
         },
         tooltip: {
-          useDefaultTimeFormat: false,
-          timeFormat: "dd MMM HH:mm",
           backgroundColor: colors.value.bg,
           color: colors.value.text,
           borderColor: colors.value.border,
@@ -271,17 +235,7 @@ const config = computed<VueUiStacklineConfig>(() => {
           fontSize: isAboveMd.value ? undefined : 10,
         },
         zoom: {
-          show: true,
-          color: colors.value.textMuted,
-          minimap: {
-            show: true,
-            selectedColorOpacity: 0.1,
-            indicatorColor: colors.value.text,
-            frameColor: colors.value.border,
-            selectedColor: colors.value.textMuted,
-            handleBorderColor: colors.value.borderLight,
-            handleFill: colors.value.bg,
-          },
+          show: false,
         },
       },
     },
@@ -291,6 +245,6 @@ const config = computed<VueUiStacklineConfig>(() => {
 
 <template>
   <ClientOnly>
-    <VueUiStackline v-if="hasEnoughHours" :dataset="dataset" :config="config" />
+    <VueUiStackline v-if="hasEnoughDays" :dataset="dataset" :config="config" />
   </ClientOnly>
 </template>

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -17,7 +17,7 @@ const props = defineProps<{
 
 const rootEl = shallowRef<HTMLElement | null>(null);
 
-onMounted(async () => {
+onMounted(() => {
   rootEl.value = document.documentElement;
 });
 
@@ -106,9 +106,36 @@ function isGitHubEventType(type: string | null): type is GitHubEventType {
   return type !== null && githubEventTypes.includes(type as GitHubEventType);
 }
 
+const eventTimestamps = computed<number[]>(() => {
+  return props.events
+    .filter((event) => event.created_at && isGitHubEventType(event.type))
+    .map((event) => new Date(event.created_at!).getTime())
+    .filter((timestamp) => !Number.isNaN(timestamp));
+});
+
+const totalDays = computed<number>(() => {
+  if (!eventTimestamps.value.length) {
+    return 0;
+  }
+
+  const firstTimestamp = Math.min(...eventTimestamps.value);
+  const lastTimestamp = Math.max(...eventTimestamps.value);
+  const oneDay = 24 * 60 * 60 * 1000;
+
+  return Math.ceil((lastTimestamp - firstTimestamp) / oneDay);
+});
+
+const chunkHours = computed<number>(() => {
+  return totalDays.value < 4 ? 1 : 6;
+});
+
 function getEventHourKey(createdAt: string): string {
   const date = new Date(createdAt);
-  date.setUTCMinutes(0, 0, 0);
+  const bucketHour =
+    Math.floor(date.getUTCHours() / chunkHours.value) * chunkHours.value;
+
+  date.setUTCHours(bucketHour, 0, 0, 0);
+
   return date.toISOString();
 }
 
@@ -123,10 +150,12 @@ const eventHours = computed<string[]>(() => {
 });
 
 const completeHours = computed<string[]>(() => {
-  return getCompleteHourRange(eventHours.value);
+  return getCompleteHourRange(eventHours.value, chunkHours.value);
 });
 
-const hasEnoughHours = computed<boolean>(() => completeHours.value.length > 1);
+const hasEnoughHours = computed<boolean>(() => {
+  return completeHours.value.length > 1;
+});
 
 function createStacklineDataset(
   events: GitHubEvent[],
@@ -141,9 +170,7 @@ function createStacklineDataset(
     if (!event.created_at || !isGitHubEventType(event.type)) {
       continue;
     }
-
     const hour = getEventHourKey(event.created_at);
-
     counts[event.type][hour] = (counts[event.type][hour] || 0) + 1;
   }
 
@@ -170,6 +197,7 @@ const config = computed<VueUiStacklineConfig>(() => {
     style: {
       chart: {
         backgroundColor: "transparent",
+        color: colors.value.textMuted,
         grid: {
           x: {
             axisColor: colors.value.border,
@@ -229,8 +257,8 @@ const config = computed<VueUiStacklineConfig>(() => {
           },
         },
         padding: {
-          left: 48,
-          right: 48,
+          left: 52,
+          right: 52,
         },
         tooltip: {
           useDefaultTimeFormat: false,
@@ -243,7 +271,17 @@ const config = computed<VueUiStacklineConfig>(() => {
           fontSize: isAboveMd.value ? undefined : 10,
         },
         zoom: {
-          show: false,
+          show: true,
+          color: colors.value.textMuted,
+          minimap: {
+            show: true,
+            selectedColorOpacity: 0.1,
+            indicatorColor: colors.value.text,
+            frameColor: colors.value.border,
+            selectedColor: colors.value.textMuted,
+            handleBorderColor: colors.value.borderLight,
+            handleFill: colors.value.bg,
+          },
         },
       },
     },

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -4,7 +4,7 @@ import {
   type VueUiStacklineDatasetItem,
   type VueUiStacklineConfig,
 } from "vue-data-ui/vue-ui-stackline";
-import { getCompleteDayRange } from "./chart";
+import { getCompleteHourRange } from "./chart";
 import type { GitHubEvent, GitHubEventType } from "~~/shared/types/identity";
 import { githubEventTypes } from "~~/shared/types/identity";
 import "vue-data-ui/style.css";
@@ -106,23 +106,31 @@ function isGitHubEventType(type: string | null): type is GitHubEventType {
   return type !== null && githubEventTypes.includes(type as GitHubEventType);
 }
 
-const eventDays = computed(() => {
+function getEventHourKey(createdAt: string): string {
+  const date = new Date(createdAt);
+  date.setUTCMinutes(0, 0, 0);
+  return date.toISOString();
+}
+
+const eventHours = computed<string[]>(() => {
   return Array.from(
     new Set(
       props.events
         .filter((event) => event.created_at && isGitHubEventType(event.type))
-        .map((event) => event.created_at!.slice(0, 10)),
+        .map((event) => getEventHourKey(event.created_at!)),
     ),
   ).sort();
 });
 
-const hasEnoughDays = computed<boolean>(() => eventDays.value.length > 1);
+const completeHours = computed<string[]>(() => {
+  return getCompleteHourRange(eventHours.value);
+});
+
+const hasEnoughHours = computed<boolean>(() => completeHours.value.length > 1);
 
 function createStacklineDataset(
   events: GitHubEvent[],
 ): VueUiStacklineDatasetItem[] {
-  const days = getCompleteDayRange(eventDays.value);
-
   const counts: Record<GitHubEventType, Record<string, number>> = {
     PullRequestEvent: {},
     CreateEvent: {},
@@ -134,15 +142,15 @@ function createStacklineDataset(
       continue;
     }
 
-    const day = event.created_at.slice(0, 10);
+    const hour = getEventHourKey(event.created_at);
 
-    counts[event.type][day] = (counts[event.type][day] || 0) + 1;
+    counts[event.type][hour] = (counts[event.type][hour] || 0) + 1;
   }
 
   return githubEventTypes.map((eventType) => ({
     name: eventConfig.value[eventType].name,
     color: eventConfig.value[eventType].color,
-    series: days.map((day) => counts[eventType][day] || 0),
+    series: completeHours.value.map((hour) => counts[eventType][hour] || 0),
   }));
 }
 
@@ -151,12 +159,9 @@ const dataset = computed<VueUiStacklineDatasetItem[]>(() => {
 });
 
 const timestamps = computed<number[]>(() => {
-  return getCompleteDayRange(eventDays.value).map((day) =>
-    new Date(day).getTime(),
-  );
+  return completeHours.value.map((hour) => new Date(hour).getTime());
 });
 
-// true: show as percentages
 const isDistributed = shallowRef(false);
 
 const config = computed<VueUiStacklineConfig>(() => {
@@ -185,6 +190,7 @@ const config = computed<VueUiStacklineConfig>(() => {
                   year: "dd MMM",
                   month: "dd MMM",
                   day: "dd MMM",
+                  hour: "dd MMM",
                   minute: "dd MMM",
                   second: "dd MMM",
                 },
@@ -227,6 +233,8 @@ const config = computed<VueUiStacklineConfig>(() => {
           right: 48,
         },
         tooltip: {
+          useDefaultTimeFormat: false,
+          timeFormat: "dd MMM HH:mm",
           backgroundColor: colors.value.bg,
           color: colors.value.text,
           borderColor: colors.value.border,
@@ -245,6 +253,6 @@ const config = computed<VueUiStacklineConfig>(() => {
 
 <template>
   <ClientOnly>
-    <VueUiStackline v-if="hasEnoughDays" :dataset="dataset" :config="config" />
+    <VueUiStackline v-if="hasEnoughHours" :dataset="dataset" :config="config" />
   </ClientOnly>
 </template>

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -8,6 +8,7 @@ import { getCompleteDayRange } from "./chart";
 import type { GitHubEvent, GitHubEventType } from "~~/shared/types/identity";
 import { githubEventTypes } from "~~/shared/types/identity";
 import "vue-data-ui/style.css";
+import { useElementSize } from "@vueuse/core";
 
 const props = defineProps<{
   events: GitHubEvent[];
@@ -19,6 +20,12 @@ const rootEl = shallowRef<HTMLElement | null>(null);
 onMounted(async () => {
   rootEl.value = document.documentElement;
 });
+
+const { width } = useElementSize(rootEl);
+
+const mdBreakpoint = 768;
+
+const isAboveMd = computed(() => width.value >= mdBreakpoint);
 
 const { colors } = useCssVariables(
   [
@@ -207,11 +214,11 @@ const config = computed<VueUiStacklineConfig>(() => {
           totalValues: { show: false },
           dataLabels: { show: false },
           path: {
-            useSerieColor: true, // new
-            stroke: "#FFFFFF", // new
+            useSerieColor: false,
+            stroke: "transparent",
           },
           dot: {
-            stroke: "#FFFFFF", // new
+            stroke: "#FFFFFF",
             radius: 0,
           },
         },
@@ -224,6 +231,8 @@ const config = computed<VueUiStacklineConfig>(() => {
           color: colors.value.text,
           borderColor: colors.value.border,
           backgroundOpacity: 30,
+          offsetY: isAboveMd.value ? -64 : undefined,
+          fontSize: isAboveMd.value ? undefined : 10,
         },
         zoom: {
           show: false,
@@ -239,3 +248,11 @@ const config = computed<VueUiStacklineConfig>(() => {
     <VueUiStackline v-if="hasEnoughDays" :dataset="dataset" :config="config" />
   </ClientOnly>
 </template>
+
+<style>
+@media screen and (min-width: 768px) {
+  .vue-data-ui-tooltip {
+    margin-left: 130px !important;
+  }
+}
+</style>

--- a/app/components/Chart/chart.ts
+++ b/app/components/Chart/chart.ts
@@ -17,17 +17,20 @@ export function getCompleteDayRange(days: string[]): string[] {
   return completeDays;
 }
 
-export function getCompleteHourRange(hours: string[]): string[] {
+export function getCompleteHourRange(
+  hours: string[],
+  chunkHours: number,
+): string[] {
   if (!hours.length) {
     return [];
   }
 
   const firstHourTime = new Date(hours[0]!).getTime();
   const lastHourTime = new Date(hours[hours.length - 1]!).getTime();
-  const oneHour = 60 * 60 * 1000;
+  const chunk = chunkHours * 60 * 60 * 1000;
   const completeHours: string[] = [];
 
-  for (let time = firstHourTime; time <= lastHourTime; time += oneHour) {
+  for (let time = firstHourTime; time <= lastHourTime; time += chunk) {
     completeHours.push(new Date(time).toISOString());
   }
 

--- a/app/components/Chart/chart.ts
+++ b/app/components/Chart/chart.ts
@@ -16,23 +16,3 @@ export function getCompleteDayRange(days: string[]): string[] {
 
   return completeDays;
 }
-
-export function getCompleteHourRange(
-  hours: string[],
-  chunkHours: number,
-): string[] {
-  if (!hours.length) {
-    return [];
-  }
-
-  const firstHourTime = new Date(hours[0]!).getTime();
-  const lastHourTime = new Date(hours[hours.length - 1]!).getTime();
-  const chunk = chunkHours * 60 * 60 * 1000;
-  const completeHours: string[] = [];
-
-  for (let time = firstHourTime; time <= lastHourTime; time += chunk) {
-    completeHours.push(new Date(time).toISOString());
-  }
-
-  return completeHours;
-}

--- a/app/components/Chart/chart.ts
+++ b/app/components/Chart/chart.ts
@@ -16,3 +16,20 @@ export function getCompleteDayRange(days: string[]): string[] {
 
   return completeDays;
 }
+
+export function getCompleteHourRange(hours: string[]): string[] {
+  if (!hours.length) {
+    return [];
+  }
+
+  const firstHourTime = new Date(hours[0]!).getTime();
+  const lastHourTime = new Date(hours[hours.length - 1]!).getTime();
+  const oneHour = 60 * 60 * 1000;
+  const completeHours: string[] = [];
+
+  for (let time = firstHourTime; time <= lastHourTime; time += oneHour) {
+    completeHours.push(new Date(time).toISOString());
+  }
+
+  return completeHours;
+}


### PR DESCRIPTION
This tweaks the chart configuration to:

- make chart lines transparent, so they are hidden when days have 0 data
- offset the tooltip to the right above the md breakpoint
- reduce the tooltip font size below the md breakpoint (in global css for now, tooltips are teleported to the body, but we can also teleport them to other targets if we want, see `tooltip.teleportTo`, we'll see maybe when / if other charts are added in the future.)
- keep day granularity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timeline now aggregates events by hour and shows a continuous hourly range so empty hours appear as zeros.
  * Responsive layout: chart and tooltip behavior adapt at the 768px breakpoint for improved readability.
  * Tooltip styling, offset and time formatting adjusted based on viewport.
  * Visual tweaks to chart paths and markers for clearer presentation; tooltip positioning refined with a larger left margin on wider screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->