### PR TITLE
chore: bump vue-data-ui from 3.19.2 to 3.19.4

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -77,9 +77,3 @@ body {
   color: var(--text);
   min-height: 100vh;
 }
-
-@media screen and (min-width: 768px) {
-  .vue-data-ui-tooltip {
-    margin-left: 130px !important;
-  }
-}

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -231,7 +231,9 @@ const config = computed<VueUiStacklineConfig>(() => {
           color: colors.value.text,
           borderColor: colors.value.border,
           backgroundOpacity: 30,
-          offsetY: isAboveMd.value ? -64 : undefined,
+          position: "right",
+          offsetX: 24,
+          offsetY: -64,
           fontSize: isAboveMd.value ? undefined : 10,
         },
         zoom: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.19.2",
+        "vue-data-ui": "^3.19.4",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13531,9 +13531,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.19.2",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.2.tgz",
-      "integrity": "sha512-4bMmADb+eHQPcTarI8OW7q4S8cZkPesKp6RwoF+DMW5OlXuPzPFI7Gg5HNo+oZn3B7eK3eiVc8Nnyo+0DvsxvQ==",
+      "version": "3.19.4",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.4.tgz",
+      "integrity": "sha512-kp12dZnHWCwCczscGbmwec9rjtCFqYFDO5Abenpn2mKaZUUNWrMwnoCVwYtdu8LeBBhs/JQLX7Ty6OjlK05kag==",
       "license": "MIT",
       "peerDependencies": {
         "jspdf": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.19.2",
+    "vue-data-ui": "^3.19.4",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update vue-data-ui to latest
- Remove css override for tooltip position
- Apply position "right" for the account timeline tooltip, with a slight offsetX

This will avoid the tooltip from overflowing on certain screen sizes, which was the downside of the previous override.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced tooltip positioning behavior in account event timeline charts by implementing fixed placement with optimized offsets, improving visual consistency across all device sizes and viewport configurations.

* **Chores**
  * Updated vue-data-ui library dependency to version 3.19.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->