### PR TITLE
fix: dynamically switch chart tooltips to optimal horizontal positions

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -9,6 +9,7 @@ import type { GitHubEvent, GitHubEventType } from "~~/shared/types/identity";
 import { githubEventTypes } from "~~/shared/types/identity";
 import "vue-data-ui/style.css";
 import { useElementSize } from "@vueuse/core";
+import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
 
 const props = defineProps<{
   events: GitHubEvent[];
@@ -16,6 +17,7 @@ const props = defineProps<{
 }>();
 
 const rootEl = shallowRef<HTMLElement | null>(null);
+const chartRef = useTemplateRef("chartRef");
 
 onMounted(async () => {
   rootEl.value = document.documentElement;
@@ -159,6 +161,8 @@ const timestamps = computed<number[]>(() => {
 // true: show as percentages
 const isDistributed = shallowRef(false);
 
+const tooltipPosition = useChartTooltipPosition(chartRef);
+
 const config = computed<VueUiStacklineConfig>(() => {
   return {
     userOptions: { show: false },
@@ -231,7 +235,7 @@ const config = computed<VueUiStacklineConfig>(() => {
           color: colors.value.text,
           borderColor: colors.value.border,
           backgroundOpacity: 30,
-          position: "right",
+          position: tooltipPosition.value,
           offsetX: 24,
           offsetY: -64,
           fontSize: isAboveMd.value ? undefined : 10,
@@ -247,6 +251,11 @@ const config = computed<VueUiStacklineConfig>(() => {
 
 <template>
   <ClientOnly>
-    <VueUiStackline v-if="hasEnoughDays" :dataset="dataset" :config="config" />
+    <VueUiStackline
+      v-if="hasEnoughDays"
+      ref="chartRef"
+      :dataset="dataset"
+      :config="config"
+    />
   </ClientOnly>
 </template>

--- a/app/components/Chart/GlobalStatusTimeline.vue
+++ b/app/components/Chart/GlobalStatusTimeline.vue
@@ -4,12 +4,14 @@ import {
   type VueUiStacklineDatasetItem,
   type VueUiStacklineConfig,
 } from "vue-data-ui/vue-ui-stackline";
+import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
 
 const props = defineProps<{
   data: Scan[] | undefined;
 }>();
 
 const rootEl = shallowRef<HTMLElement | null>(null);
+const chartRef = useTemplateRef("chartRef");
 
 onMounted(async () => {
   rootEl.value = document.documentElement;
@@ -111,6 +113,8 @@ const timestamps = computed(() => {
 // true: show as percentages
 const isDistributed = shallowRef(false);
 
+const tooltipPosition = useChartTooltipPosition(chartRef);
+
 const config = computed<VueUiStacklineConfig>(() => {
   return {
     userOptions: { show: false },
@@ -181,6 +185,9 @@ const config = computed<VueUiStacklineConfig>(() => {
           color: colors.value.text,
           borderColor: colors.value.border,
           backgroundOpacity: 30,
+          position: tooltipPosition.value,
+          offsetX: 24,
+          offsetY: -64,
         },
         zoom: {
           show: false,
@@ -198,7 +205,7 @@ const config = computed<VueUiStacklineConfig>(() => {
       <input type="checkbox" v-model="isDistributed" />
     </label>
     <ClientOnly>
-      <VueUiStackline :dataset :config> </VueUiStackline>
+      <VueUiStackline ref="chartRef" :dataset :config> </VueUiStackline>
     </ClientOnly>
   </div>
 </template>

--- a/app/composables/useChartTooltipPosition.ts
+++ b/app/composables/useChartTooltipPosition.ts
@@ -1,0 +1,26 @@
+/**
+ * This composable returns a dynamic position to be fed to vue-data-ui components configugration for the `tooltip.position` attribute.
+ */
+
+import { useMouseInElement } from "@vueuse/core";
+
+type TooltipPosition = "left" | "right" | "center";
+type TemplateRefValue = HTMLElement | { $el?: HTMLElement } | null | undefined;
+
+export function useChartTooltipPosition(
+  chartRef: MaybeRefOrGetter<TemplateRefValue>,
+): ComputedRef<TooltipPosition> {
+  const target = computed<HTMLElement | null>(() => {
+    const value = toValue(chartRef);
+    if (!value) return null;
+    if (value instanceof HTMLElement) return value;
+    return value.$el || null;
+  });
+
+  const { elementX, elementWidth, isOutside } = useMouseInElement(target);
+
+  return computed<TooltipPosition>(() => {
+    if (isOutside.value || elementWidth.value === 0) return "center";
+    return elementX.value > elementWidth.value / 2 ? "left" : "right";
+  });
+}


### PR DESCRIPTION
This adds a `useChartTooltipPosition` composable to dynamically set the `tooltip.position` attribute for vue-data-ui charts, based on the client position relative to the horizontal middle of the chart component.

Applied to both timeline charts.

https://github.com/user-attachments/assets/dd7fcaaa-9558-4909-b566-34d453ca38f1



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chart tooltips now intelligently position themselves based on cursor location, automatically selecting the optimal placement (left, right, or center) to ensure information remains clearly readable across timeline charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->