### PR TITLE
feat: update charts in health page

### DIFF
--- a/app/components/Chart/AccountEventsDonut.vue
+++ b/app/components/Chart/AccountEventsDonut.vue
@@ -4,6 +4,7 @@ import {
   type VueUiDonutDatasetItem,
   type VueUiDonutConfig,
 } from "vue-data-ui/vue-ui-donut";
+import { useColors } from "~/composables/useColors";
 
 const props = defineProps<{
   events: GitHubEvent[];
@@ -60,30 +61,7 @@ onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
-const { colors } = useCssVariables(
-  [
-    "--bg",
-    "--card",
-    "--border",
-    "--border-light",
-    "--text",
-    "--text-muted",
-    "--blue",
-    "--green",
-    "--green-hover",
-    "--text-green",
-    "--green-bg",
-    "--danger",
-    "--danger-hover",
-    "--danger-bg",
-    "--red",
-    "--red-hover",
-    "--red-bg",
-  ],
-  {
-    element: rootEl,
-  },
-);
+const colors = useColors(rootEl);
 
 const config = computed<VueUiDonutConfig>(() => {
   return {

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -10,6 +10,9 @@ import { githubEventTypes } from "~~/shared/types/identity";
 import "vue-data-ui/style.css";
 import { useElementSize } from "@vueuse/core";
 import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
+import { useColors } from "~/composables/useColors";
+
+import("vue-data-ui/style.css");
 
 const props = defineProps<{
   events: GitHubEvent[];
@@ -23,48 +26,12 @@ onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
+const colors = useColors(rootEl);
 const { width } = useElementSize(rootEl);
 
 const mdBreakpoint = 768;
 
 const isAboveMd = computed(() => width.value >= mdBreakpoint);
-
-const { colors } = useCssVariables(
-  [
-    "--bg",
-    "--card",
-    "--border",
-    "--border-light",
-    "--text",
-    "--text-muted",
-    "--blue",
-    "--green",
-    "--green-hover",
-    "--text-green",
-    "--green-bg",
-    "--danger",
-    "--danger-hover",
-    "--danger-bg",
-    "--red",
-    "--red-hover",
-    "--red-bg",
-    "--event-fork",
-    "--event-branch",
-    "--event-pr",
-    "--event-organic-pr",
-    "--event-organic-branch",
-    "--event-organic-fork",
-    "--event-mixed-pr",
-    "--event-mixed-branch",
-    "--event-mixed-fork",
-    "--event-automation-pr",
-    "--event-automation-branch",
-    "--event-automation-fork",
-  ],
-  {
-    element: rootEl,
-  },
-);
 
 const eventConfig = computed(() => {
   const classification = props.classification || "mixed";

--- a/app/components/Chart/GlobalEventsBreakdown.vue
+++ b/app/components/Chart/GlobalEventsBreakdown.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import {
+  VueUiSparkStackbar,
+  type VueUiSparkStackbarDatasetItem,
+  type VueUiSparkStackbarConfig,
+} from "vue-data-ui/vue-ui-sparkstackbar";
+import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
+import { useColors } from "~/composables/useColors";
+
+import("vue-data-ui/style.css");
+
+const props = defineProps<{
+  data: Array<VueUiStacklineDatasetItem>;
+}>();
+
+const rootEl = shallowRef<HTMLElement | null>(null);
+
+onMounted(() => {
+  rootEl.value = document.documentElement;
+});
+
+const colors = useColors(rootEl);
+
+const dataset = computed<VueUiSparkStackbarDatasetItem[]>(() =>
+  props.data.map((d) => ({
+    ...d,
+    value: d.series.reduce((a, b) => (a ?? 0) + (b ?? 0), 0),
+  })),
+);
+
+const config = computed<VueUiSparkStackbarConfig>(() => ({
+  style: {
+    backgroundColor: colors.value.bg,
+    animation: { show: false },
+    bar: {
+      gradient: { show: false },
+    },
+    legend: {
+      textAlign: "center",
+      name: {
+        color: colors.value.text,
+      },
+      percentage: {
+        bold: false,
+        color: colors.value.textMuted,
+      },
+      value: {
+        color: colors.value.textMuted,
+      },
+    },
+    tooltip: { show: false },
+  },
+}));
+</script>
+
+<template>
+  <ClientOnly>
+    <VueUiSparkStackbar :dataset :config></VueUiSparkStackbar>
+  </ClientOnly>
+</template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -1,0 +1,150 @@
+<script setup lang="ts">
+import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
+import {
+  VueUiXy,
+  type VueUiXyDatasetItem,
+  type VueUiXyConfig,
+} from "vue-data-ui/vue-ui-xy";
+import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
+import { useColors } from "~/composables/useColors";
+
+const props = defineProps<{
+  data: VueUiStacklineDatasetItem[];
+  timestamps: string[];
+}>();
+
+const rootEl = shallowRef<HTMLElement | null>(null);
+const chartRef = useTemplateRef("chartRef");
+
+onMounted(async () => {
+  rootEl.value = document.documentElement;
+});
+
+const colors = useColors(rootEl);
+
+const dataset = computed<VueUiXyDatasetItem[]>(() =>
+  props.data.map((d) => ({
+    ...d,
+    type: "line",
+    smooth: true,
+    useArea: true,
+  })),
+);
+
+const tooltipPosition = useChartTooltipPosition(chartRef);
+
+const config = computed<VueUiXyConfig>(() => ({
+  chart: {
+    userOptions: { show: false },
+    backgroundColor: "transparent",
+    color: colors.value.textMuted,
+    padding: {
+      left: 0,
+      right: 90,
+    },
+    grid: {
+      stroke: colors.value.borderLight,
+      showHorizontalLines: true,
+      showVerticalLines: true,
+      labels: {
+        color: colors.value.textMuted,
+        fontSize: 24,
+        axis: {
+          yLabel: "number of evaluated accounts",
+          yLabelOffsetX: 18,
+          fontSize: 24,
+        },
+        xAxisLabels: {
+          values: props.timestamps,
+          color: colors.value.textMuted,
+          fontSize: 20,
+          showOnlyAtModulo: true,
+          modulo: 12,
+          rotation: -30,
+          autoRotate: {
+            enable: false,
+          },
+          datetimeFormatter: {
+            enable: true,
+            useUTC: true,
+            locale: "en",
+            options: {
+              year: "dd MMM",
+              month: "dd MMM",
+              day: "dd MMM",
+              minute: "dd MMM",
+              second: "dd MMM",
+            },
+          },
+        },
+        yAxis: {
+          useNiceScale: true,
+          commonScaleSteps: 5,
+        },
+      },
+    },
+    highlighter: {
+      color: colors.value.text,
+    },
+    legend: { show: false },
+    tooltip: {
+      backgroundColor: colors.value.bg,
+      color: colors.value.text,
+      borderColor: colors.value.border,
+      backgroundOpacity: 30,
+      position: tooltipPosition.value,
+      offsetX: 24,
+      offsetY: -44,
+    },
+    zoom: {
+      show: true,
+      color: colors.value.text,
+      keepState: true,
+      preview: {
+        strokeDasharray: 6,
+        fill: "transparent",
+      },
+      minimap: {
+        show: true,
+        selectedColor: colors.value.textMuted,
+        selectedColorOpacity: 0.15,
+        indicatorColor: colors.value.text,
+        handleFill: colors.value.bg,
+        frameColor: colors.value.borderLight,
+      },
+    },
+  },
+}));
+</script>
+
+<template>
+  <ClientOnly>
+    <VueUiXy ref="chartRef" :dataset :config>
+      <template #area-gradient="{ series, id }">
+        <linearGradient :id x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" :stop-color="series.color" stop-opacity="0.3" />
+          <stop offset="100%" :stop-color="colors.bg" stop-opacity="0" />
+        </linearGradient>
+      </template>
+
+      <template #tooltip="{ datapoint, timeLabel }">
+        <div class="flex flex-col">
+          <div class="mb-1">{{ timeLabel.text }}</div>
+          <div
+            class="flex flex-row gap-2 items-center"
+            v-for="series in datapoint"
+            :key="`${series.name}-${series.absoluteIndex}`"
+          >
+            <div class="h-3 w-3">
+              <svg viewBox="0 0 2 2" class="w-full h-full">
+                <circle cx="1" cy="1" r="1" :fill="series.color" />
+              </svg>
+            </div>
+            <span :style="{ color: colors.textMuted }">{{ series.name }}</span>
+            <span>{{ series.value }}</span>
+          </div>
+        </div>
+      </template>
+    </VueUiXy>
+  </ClientOnly>
+</template>

--- a/app/components/Chart/GlobalEventsSplitSparklines.vue
+++ b/app/components/Chart/GlobalEventsSplitSparklines.vue
@@ -1,0 +1,167 @@
+<script setup lang="ts">
+import {
+  VueUiSparkline,
+  type VueUiSparklineConfig,
+  type VueUiSparklineDatasetItem,
+} from "vue-data-ui/vue-ui-sparkline";
+import { getPalette } from "vue-data-ui/utils";
+import { useColors } from "~/composables/useColors";
+import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
+
+import("vue-data-ui/style.css");
+
+const props = defineProps<{
+  dataset?: Array<VueUiStacklineDatasetItem>;
+  dates: string[];
+  selectedXIndex: number | undefined;
+}>();
+
+const emit = defineEmits<{
+  (e: "selectIndex", selectedIndex: number | undefined): void;
+}>();
+
+const rootEl = shallowRef<HTMLElement | null>(null);
+const palette = getPalette("");
+
+const step = ref(0);
+
+onMounted(() => {
+  rootEl.value = document.documentElement;
+});
+
+const colors = useColors(rootEl);
+
+const datasets = computed<VueUiSparklineDatasetItem[][]>(() => {
+  return (props.dataset ?? []).map((unit) => {
+    return props.dates.map((period, i) => {
+      return {
+        period,
+        value: unit.series[i] ?? 0,
+      };
+    });
+  });
+});
+
+const selectedIndex = computed<number | undefined>({
+  get() {
+    return props.selectedXIndex;
+  },
+  set(value) {
+    emit("selectIndex", value);
+  },
+});
+
+function hoverIndex({ index }: { index: number | undefined | null }) {
+  selectedIndex.value = typeof index === "number" ? index : undefined;
+}
+
+function resetHover() {
+  selectedIndex.value = undefined;
+  step.value += 1;
+}
+
+const configs = computed(() => {
+  return (props.dataset || []).map<VueUiSparklineConfig>((unit, i) => {
+    const dashIndices = unit.dashIndices;
+
+    // Ensure we loop through available palette colours when the series count is higher than the available palette
+    const fallbackColor =
+      palette[i] ?? palette[i % palette.length] ?? palette[0]!;
+    const seriesColor = unit.color ?? fallbackColor;
+
+    return {
+      skeletonConfig: {
+        style: {
+          backgroundColor: "transparent",
+          dataLabel: {
+            show: true,
+            color: "transparent",
+          },
+          area: {
+            color: colors.value.borderHover,
+            useGradient: false,
+            opacity: 10,
+          },
+          line: {
+            color: colors.value.borderHover,
+          },
+        },
+      },
+      skeletonDataset: Array.from({ length: unit.series.length }, () => 0),
+      style: {
+        backgroundColor: "transparent",
+        animation: { show: false },
+        chartWidth: 400,
+        area: {
+          color: unit.color,
+          useGradient: false,
+          opacity: 10,
+        },
+        dataLabel: {
+          offsetX: -12,
+          fontSize: 36,
+          bold: false,
+          color: unit.color,
+          formatter: ({ value }) => {
+            return Math.round(value);
+          },
+          datetimeFormatter: {
+            enable: true,
+            locale: "en",
+            useUTC: true,
+          },
+        },
+        line: {
+          smooth: true,
+          color: seriesColor,
+          dashIndices,
+          dashArray: 3,
+        },
+        plot: {
+          radius: 6,
+          stroke: colors.value.bg,
+        },
+        title: {
+          show: false,
+        },
+        verticalIndicator: {
+          strokeDasharray: 0,
+          color: colors.value.text,
+        },
+        padding: {
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+        },
+      },
+    };
+  });
+});
+</script>
+
+<template>
+  <div class="grid gap-8 sm:grid-cols-3 sm:px-16 mb-4">
+    <ClientOnly v-for="(config, i) in configs" :key="`config_${i}`">
+      <div
+        @mouseleave="resetHover"
+        @keydown.esc="resetHover"
+        class="w-full max-w-[400px] mx-auto"
+      >
+        <VueUiSparkline
+          v-if="datasets[i]"
+          :key="`${i}_${step}`"
+          :config
+          :dataset="datasets[i]"
+          :selectedIndex
+          @hoverIndex="hoverIndex"
+        >
+          <template #skeleton>
+            <!-- This empty div overrides the default built-in scanning animation on load -->
+            <div></div>
+          </template>
+        </VueUiSparkline>
+      </div>
+    </ClientOnly>
+  </div>
+</template>

--- a/app/components/Chart/GlobalEventsSplitSparklines.vue
+++ b/app/components/Chart/GlobalEventsSplitSparklines.vue
@@ -70,24 +70,6 @@ const configs = computed(() => {
     const seriesColor = unit.color ?? fallbackColor;
 
     return {
-      skeletonConfig: {
-        style: {
-          backgroundColor: "transparent",
-          dataLabel: {
-            show: true,
-            color: "transparent",
-          },
-          area: {
-            color: colors.value.borderHover,
-            useGradient: false,
-            opacity: 10,
-          },
-          line: {
-            color: colors.value.borderHover,
-          },
-        },
-      },
-      skeletonDataset: Array.from({ length: unit.series.length }, () => 0),
       style: {
         backgroundColor: "transparent",
         animation: { show: false },

--- a/app/components/Chart/GlobalScatter.vue
+++ b/app/components/Chart/GlobalScatter.vue
@@ -7,7 +7,7 @@ import {
 } from "vue-data-ui/vue-ui-scatter";
 
 import "vue-data-ui/style.css";
-import { useCssVariables } from "~/composables/useColors";
+import { useColors } from "~/composables/useColors";
 
 const props = defineProps<{
   data: Scan[] | undefined;
@@ -19,30 +19,7 @@ onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
-const { colors } = useCssVariables(
-  [
-    "--bg",
-    "--card",
-    "--border",
-    "--border-light",
-    "--text",
-    "--text-muted",
-    "--blue",
-    "--green",
-    "--green-hover",
-    "--text-green",
-    "--green-bg",
-    "--danger",
-    "--danger-hover",
-    "--danger-bg",
-    "--red",
-    "--red-hover",
-    "--red-bg",
-  ],
-  {
-    element: rootEl,
-  },
-);
+const colors = useColors(rootEl);
 
 type ScatterClusterParams = {
   dataset: Scan[];

--- a/app/components/Chart/GlobalScoreGauge.vue
+++ b/app/components/Chart/GlobalScoreGauge.vue
@@ -6,7 +6,7 @@ import {
 } from "vue-data-ui/vue-ui-gauge";
 
 import "vue-data-ui/style.css";
-import { useCssVariables } from "~/composables/useColors";
+import { useColors } from "~/composables/useColors";
 
 const props = defineProps<{
   data: Scan[] | undefined;
@@ -18,42 +18,7 @@ onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
-const { colors } = useCssVariables(
-  [
-    "--bg",
-    "--card",
-    "--border",
-    "--border-light",
-    "--text",
-    "--text-muted",
-    "--blue",
-    "--green",
-    "--green-hover",
-    "--text-green",
-    "--green-bg",
-    "--danger",
-    "--danger-hover",
-    "--danger-bg",
-    "--red",
-    "--red-hover",
-    "--red-bg",
-    "--event-fork",
-    "--event-branch",
-    "--event-pr",
-    "--event-organic-pr",
-    "--event-organic-branch",
-    "--event-organic-fork",
-    "--event-mixed-pr",
-    "--event-mixed-branch",
-    "--event-mixed-fork",
-    "--event-automation-pr",
-    "--event-automation-branch",
-    "--event-automation-fork",
-  ],
-  {
-    element: rootEl,
-  },
-);
+const colors = useColors(rootEl);
 
 const averageScoreOverall = computed(() => {
   const count = (props.data ?? []).length;

--- a/app/components/Chart/GlobalStatusDashboard.vue
+++ b/app/components/Chart/GlobalStatusDashboard.vue
@@ -5,6 +5,7 @@ import {
   type VueUiStacklineConfig,
 } from "vue-data-ui/vue-ui-stackline";
 import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
+import { useColors } from "~/composables/useColors";
 
 const props = defineProps<{
   data: Scan[] | undefined;
@@ -17,30 +18,7 @@ onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
-const { colors } = useCssVariables(
-  [
-    "--bg",
-    "--card",
-    "--border",
-    "--border-light",
-    "--text",
-    "--text-muted",
-    "--blue",
-    "--green",
-    "--green-hover",
-    "--text-green",
-    "--green-bg",
-    "--danger",
-    "--danger-hover",
-    "--danger-bg",
-    "--red",
-    "--red-hover",
-    "--red-bg",
-  ],
-  {
-    element: rootEl,
-  },
-);
+const colors = useColors(rootEl);
 
 function createStacklineDataset(source: Scan[] = []): {
   categories: string[];
@@ -83,9 +61,9 @@ function createStacklineDataset(source: Scan[] = []): {
     categories,
     dataset: [
       {
-        name: "organic",
-        series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
-        color: colors.value.green,
+        name: "automated",
+        series: categories.map((date) => sumsByDate[date]?.automated ?? 0),
+        color: colors.value.red,
       },
       {
         name: "mixed",
@@ -93,9 +71,9 @@ function createStacklineDataset(source: Scan[] = []): {
         color: colors.value.dangerHover,
       },
       {
-        name: "automated",
-        series: categories.map((date) => sumsByDate[date]?.automated ?? 0),
-        color: colors.value.red,
+        name: "organic",
+        series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
+        color: colors.value.green,
       },
     ],
   };
@@ -121,7 +99,7 @@ const config = computed<VueUiStacklineConfig>(() => {
     style: {
       chart: {
         backgroundColor: "transparent",
-        height: 300,
+        height: 255,
         grid: {
           stroke: colors.value.border,
           x: {
@@ -156,14 +134,16 @@ const config = computed<VueUiStacklineConfig>(() => {
         },
         highlighter: {
           color: colors.value.text,
+          useLine: true,
         },
         legend: {
+          show: false,
           backgroundColor: "transparent",
           color: colors.value.textMuted,
         },
         lines: {
           useArea: true,
-          areaOpacity: 1,
+          areaOpacity: 0.3,
           smooth: true,
           distributed: isDistributed.value,
           gradient: { show: false },
@@ -196,22 +176,40 @@ const config = computed<VueUiStacklineConfig>(() => {
     },
   };
 });
+
+const selectedIndex = shallowRef<number | undefined>(undefined);
+
+function setSelectedIndex(
+  payload:
+    | number
+    | { index?: number; selectedIndex?: number; seriesIndex?: number }
+    | undefined
+    | null,
+) {
+  if (typeof payload === "number") {
+    selectedIndex.value = payload;
+    return;
+  }
+
+  selectedIndex.value = payload?.index ?? payload?.selectedIndex ?? undefined;
+}
 </script>
 
 <template>
   <div>
-    <label>
-      Distributed
-      <input type="checkbox" v-model="isDistributed" />
-    </label>
-    <ClientOnly>
-      <VueUiStackline ref="chartRef" :dataset :config> </VueUiStackline>
-    </ClientOnly>
+    <div class="max-w-[450px] mx-auto mb-12">
+      <ChartGlobalEventsBreakdown :data="dataset" />
+    </div>
+
+    <ChartGlobalEventsSplitSparklines
+      :dataset
+      :dates="timestamps"
+      :selectedXIndex="selectedIndex"
+      @selectIndex="setSelectedIndex"
+    />
+
+    <div class="max-w-[500px] mx-auto mt-12">
+      <ChartGlobalEventsEvolution :data="dataset" :timestamps />
+    </div>
   </div>
 </template>
-
-<style scoped>
-:deep(.vue-data-ui-component svg path:nth-of-type(n + 3)) {
-  stroke: var(--bg) !important;
-}
-</style>

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -116,7 +116,6 @@ export function useColors(
       "--event-automation-pr",
       "--event-automation-branch",
       "--event-automation-fork",
-      "--chart-transparent-selection",
     ],
     {
       element,

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -1,4 +1,10 @@
-import { computed, type ComputedRef, type Ref, unref } from "vue";
+import {
+  computed,
+  type ComputedRef,
+  type Ref,
+  type ShallowRef,
+  unref,
+} from "vue";
 import { useSupported } from "@vueuse/core";
 
 type CssVariableSource =
@@ -74,4 +80,47 @@ export function useCssVariables(
   });
 
   return { colors };
+}
+
+export function useColors(
+  element: ShallowRef<HTMLElement | null, HTMLElement | null>,
+) {
+  const { colors } = useCssVariables(
+    [
+      "--bg",
+      "--card",
+      "--border",
+      "--border-light",
+      "--text",
+      "--text-muted",
+      "--blue",
+      "--green",
+      "--green-hover",
+      "--text-green",
+      "--green-bg",
+      "--danger",
+      "--danger-hover",
+      "--danger-bg",
+      "--red",
+      "--red-hover",
+      "--red-bg",
+      "--event-fork",
+      "--event-branch",
+      "--event-pr",
+      "--event-organic-pr",
+      "--event-organic-branch",
+      "--event-organic-fork",
+      "--event-mixed-pr",
+      "--event-mixed-branch",
+      "--event-mixed-fork",
+      "--event-automation-pr",
+      "--event-automation-branch",
+      "--event-automation-fork",
+      "--chart-transparent-selection",
+    ],
+    {
+      element,
+    },
+  );
+  return colors;
 }

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -15,12 +15,7 @@ definePageMeta({
       loading data...
     </div>
     <div v-else-if="data" class="space-y-1">
-      <div class="max-w-[300px] mx-auto">
-        <ChartGlobalScoreGauge :data />
-      </div>
-
-      <!-- Aggregated categories through time: very nice to see the evolution of organic / mixed / automated -->
-      <ChartGlobalStatusTimeline :data />
+      <ChartGlobalStatusDashboard :data />
     </div>
     <div v-else-if="error" class="text-red-600 dark:text-red-400 text-sm">
       {{ error.message }}


### PR DESCRIPTION
This updates the health page charts with:

- a mini horizontal bar with breakdowns per profile type
- sparklines (individual evolution per type)
- line chart with all types + zoom (handy when the dataset will become large)

<img width="1005" height="616" alt="image" src="https://github.com/user-attachments/assets/fe7a8739-7f9d-40cf-868e-c30094a6decc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added events breakdown chart for summarized event data visualization.
  * Added events evolution chart showing historical event trends over time.
  * Added split sparklines chart for per-series event analysis.

* **Changes**
  * Redesigned the Global Status Dashboard with a multi-component layout.
  * Updated health page to display the new dashboard composition.
  * Improved chart color system for consistent theming across all visualizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->