### PR TITLE
chore: redirect to .tools domain

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+https://agentscan.netlify.app/* https://agentscan.tools/:splat 301

--- a/scripts/scan-users.ts
+++ b/scripts/scan-users.ts
@@ -11,7 +11,7 @@ const STATIC_SALT = "agentscan-v1";
 const USERS_TO_SCAN = 100;
 const MAX_PAGES = 10; // Search up to 10 pages to find enough unscanned users
 const API_TIMEOUT = 10000; // 10 seconds timeout for API calls
-const API_BASE_URL = "https://agentscan.netlify.app";
+const API_BASE_URL = "https://agentscan.tools";
 const DELAY_BETWEEN_SCANS = 1000; // 1 second conservative delay between identify-replicant API calls
 const DELAY_BETWEEN_GITHUB_CALLS = 200; // 200ms delay between GitHub API calls (random user fetches)
 

--- a/server/routes/feed.xml.ts
+++ b/server/routes/feed.xml.ts
@@ -30,7 +30,7 @@ export default defineEventHandler(async (event) => {
 });
 
 function generateRSSFeed(automations: VerifiedAutomation[]): string {
-  const baseUrl = "https://agentscan.netlify.app";
+  const baseUrl = "https://agentscan.tools";
   const lastBuildDate = new Date().toUTCString();
   const feedLastUpdate = automations[0]
     ? new Date(automations[0].createdAt).toUTCString()


### PR DESCRIPTION
redirect to new agentscan.tools domain name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Application domain migrated to agentscan.tools with automatic HTTP redirects from the previous domain
- All existing bookmarks and shared links remain functional through automatic redirects
- Updated API endpoints and RSS feed configuration to use the new domain
- No user action required; transition is seamless and transparent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->