### PR TITLE
chore: bump vue-data-ui from 3.19.4 to 3.19.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.19.4",
+        "vue-data-ui": "^3.19.5",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13531,9 +13531,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.19.4",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.4.tgz",
-      "integrity": "sha512-kp12dZnHWCwCczscGbmwec9rjtCFqYFDO5Abenpn2mKaZUUNWrMwnoCVwYtdu8LeBBhs/JQLX7Ty6OjlK05kag==",
+      "version": "3.19.5",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.5.tgz",
+      "integrity": "sha512-mLfiveMh4p3/xeXLB/30IkO1b8tc8wJLBv2Ajo32kJTPgpEO814Z8tZS4BRKGJsuFtkGOt6FZVD/rgslM+xRiQ==",
       "license": "MIT",
       "peerDependencies": {
         "jspdf": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.19.4",
+    "vue-data-ui": "^3.19.5",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This release fixes an issue causing a refresh of `VueUiStackline` legend when the config is dynamically updated (here with the tooltip position), and preventing the filtering of series.

Test:
- on the chart of the account page, filter out a series by clicking on its legend item
- hover the chart
- the legend state should remain the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `vue-data-ui` dependency to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->