### PR TITLE
fix: various chart fixes

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -55,6 +55,7 @@
   --blue: #0969da;
   --green: #1a7f37;
   --green-hover: #2ea043;
+  --green-line: #22c55e;
   --text-green: #116329;
   --green-bg: #dafbe1;
   --danger: #ea580c;

--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -17,6 +17,7 @@
   --green: #238636;
   --green-hover: #2ea043;
   --text-green: #3fb950;
+  --green-line: #22c55e;
   --green-bg: #0d2818;
   --danger: #ea580c;
   --danger-hover: #f97316;

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -111,11 +111,11 @@ const config = computed<VueUiXyConfig>(() => ({
         <div class="flex flex-col">
           <div class="mb-1">{{ timeLabel.text }}</div>
           <div
-            class="flex flex-row gap-2 items-center"
+            class="flex flex-row gap-2 place-items-center"
             v-for="series in datapoint"
             :key="`${series.name}-${series.absoluteIndex}`"
           >
-            <div class="h-3 w-3">
+            <div class="h-2 w-2 -mb-1">
               <svg viewBox="0 0 2 2" class="w-full h-full">
                 <circle cx="1" cy="1" r="1" :fill="series.color" />
               </svg>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -109,7 +109,9 @@ const config = computed<VueUiXyConfig>(() => ({
 
       <template #tooltip="{ datapoint, timeLabel }">
         <div class="flex flex-col">
-          <div class="mb-1">{{ timeLabel.text }}</div>
+          <div :style="{ color: colors.textMuted }" class="mb-1">
+            {{ timeLabel.text }}
+          </div>
           <div
             class="flex flex-row gap-2 place-items-center"
             v-for="series in datapoint"
@@ -120,8 +122,8 @@ const config = computed<VueUiXyConfig>(() => ({
                 <circle cx="1" cy="1" r="1" :fill="series.color" />
               </svg>
             </div>
-            <span :style="{ color: colors.textMuted }">{{ series.name }}</span>
-            <span>{{ series.value }}</span>
+            <span :style="{ color: colors.text }">{{ series.name }}</span>
+            <span :style="{ color: colors.textMuted }">{{ series.value }}</span>
           </div>
         </div>
       </template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -117,7 +117,7 @@ const config = computed<VueUiXyConfig>(() => ({
             v-for="series in datapoint"
             :key="`${series.name}-${series.absoluteIndex}`"
           >
-            <div class="h-2 w-2 -mb-1">
+            <div class="h-2 w-2">
               <svg viewBox="0 0 2 2" class="w-full h-full">
                 <circle cx="1" cy="1" r="1" :fill="series.color" />
               </svg>

--- a/app/components/Chart/GlobalStatusDashboard.vue
+++ b/app/components/Chart/GlobalStatusDashboard.vue
@@ -16,7 +16,7 @@ onMounted(async () => {
 
 const colors = useColors(rootEl);
 
-function createStacklineDataset(source: Scan[] = []): {
+function createChartDataset(source: Scan[] = []): {
   categories: string[];
   dataset: VueUiStacklineDatasetItem[];
 } {
@@ -75,7 +75,7 @@ function createStacklineDataset(source: Scan[] = []): {
   };
 }
 
-const stacklineData = computed(() => createStacklineDataset(props.data ?? []));
+const stacklineData = computed(() => createChartDataset(props.data ?? []));
 const dataset = computed(() => stacklineData.value.dataset);
 
 const timestamps = computed(() => {

--- a/app/components/Chart/GlobalStatusDashboard.vue
+++ b/app/components/Chart/GlobalStatusDashboard.vue
@@ -25,7 +25,7 @@ function createStacklineDataset(source: Scan[] = []): {
   const sumsByDate: Record<
     string,
     {
-      autiomation: number;
+      automation: number;
       mixed: number;
       organic: number;
     }
@@ -33,7 +33,7 @@ function createStacklineDataset(source: Scan[] = []): {
 
   categories.forEach((date) => {
     sumsByDate[date] = {
-      autiomation: 0,
+      automation: 0,
       mixed: 0,
       organic: 0,
     };
@@ -45,7 +45,7 @@ function createStacklineDataset(source: Scan[] = []): {
     if (!dateSums) return;
 
     if (item.score <= 50) {
-      dateSums.autiomation += 1;
+      dateSums.automation += 1;
     } else if (item.score <= 70) {
       dateSums.mixed += 1;
     } else {
@@ -57,19 +57,19 @@ function createStacklineDataset(source: Scan[] = []): {
     categories,
     dataset: [
       {
-        name: "autiomation",
-        series: categories.map((date) => sumsByDate[date]?.autiomation ?? 0),
-        color: colors.value.red,
+        name: "Organic",
+        series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
+        color: colors.value.greenLine,
       },
       {
-        name: "mixed",
+        name: "Mixed",
         series: categories.map((date) => sumsByDate[date]?.mixed ?? 0),
         color: colors.value.amber,
       },
       {
-        name: "organic",
-        series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
-        color: colors.value.green,
+        name: "Automation",
+        series: categories.map((date) => sumsByDate[date]?.automation ?? 0),
+        color: colors.value.dangerHover,
       },
     ],
   };

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -95,6 +95,7 @@ export function useColors(
       "--text-muted",
       "--blue",
       "--green",
+      "--green-line",
       "--green-hover",
       "--text-green",
       "--green-bg",


### PR DESCRIPTION
Minor fixes:

- add green color corresponding to the tailwind var used in the legend
- fix 'autiomation' typo
- reverse series order to make tooltip order more consistent (1.organic, 2.mixed, 3.automation)
- update styles for the tooltip to make it more consistent with the legend:
  - smaller markers
  - same text color logic
<img width="221" height="260" alt="image" src="https://github.com/user-attachments/assets/ed50a5eb-41c3-4e8e-a336-01d783324537" />

