### PR TITLE
feat: add heatmaps POC

### DIFF
--- a/app/components/Chart/GlobalEventsHeatmap.vue
+++ b/app/components/Chart/GlobalEventsHeatmap.vue
@@ -1,0 +1,233 @@
+<script setup lang="ts">
+import {
+  VueUiHeatmap,
+  type VueUiHeatmapDatasetItem,
+  type VueUiHeatmapConfig,
+  type VueUiHeatmapDatapoint,
+} from "vue-data-ui/vue-ui-heatmap";
+import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
+import dayjs from "dayjs";
+import isoWeek from "dayjs/plugin/isoWeek";
+import { mergeConfigs } from "vue-data-ui/utils";
+
+dayjs.extend(isoWeek);
+
+import("vue-data-ui/style.css");
+
+const props = defineProps<{
+  data: VueUiStacklineDatasetItem[];
+  timestamps: string[];
+}>();
+
+const rootEl = shallowRef<HTMLElement | null>(null);
+
+onMounted(() => {
+  rootEl.value = document.documentElement;
+});
+
+const colors = useColors(rootEl);
+
+const daysOfWeek = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+const dayIndexes = daysOfWeek.reduce(
+  (accumulator, dayName, dayIndex) => {
+    accumulator[dayName] = dayIndex;
+    return accumulator;
+  },
+  {} as Record<string, number>,
+);
+
+const heatmapSeries = computed(() => [
+  {
+    name: "Organic",
+    color: colors.value.greenLine,
+  },
+  {
+    name: "Mixed",
+    color: colors.value.amber,
+  },
+  {
+    name: "Automation",
+    color: colors.value.dangerHover,
+  },
+]);
+
+const weekKeys = computed(() =>
+  [
+    ...new Set(
+      props.timestamps.map((timestamp) =>
+        dayjs(timestamp).startOf("isoWeek").format("YYYY-MM-DD"),
+      ),
+    ),
+  ].sort(),
+);
+
+const weekLabels = computed(() =>
+  weekKeys.value.map((weekKey) => {
+    const start = dayjs(weekKey);
+    const end = start.endOf("isoWeek");
+
+    return `${start.format("MMM D")} - ${end.format("MMM D")}`;
+  }),
+);
+
+function createHeatmapDataset(
+  dataset: VueUiStacklineDatasetItem[],
+  timestamps: string[],
+  seriesName: string,
+): VueUiHeatmapDatasetItem[] {
+  const selectedSeries = dataset.find(
+    (seriesItem) => seriesItem.name === seriesName,
+  );
+
+  if (!selectedSeries) {
+    return daysOfWeek.map((dayName) => ({
+      name: dayName,
+      values: [],
+    }));
+  }
+
+  const valuesByWeekAndDay = new Map<string, number[]>();
+
+  timestamps.forEach((timestamp, timestampIndex) => {
+    const date = dayjs(timestamp);
+    const weekKey = date.startOf("isoWeek").format("YYYY-MM-DD");
+    const dayIndex = date.isoWeekday() - 1;
+
+    const weekValues = valuesByWeekAndDay.get(weekKey) ?? [0, 0, 0, 0, 0, 0, 0];
+
+    weekValues[dayIndex] =
+      (weekValues[dayIndex] ?? 0) +
+      (selectedSeries.series[timestampIndex] ?? 0);
+
+    valuesByWeekAndDay.set(weekKey, weekValues);
+  });
+
+  return daysOfWeek.map((dayName, dayIndex) => ({
+    name: dayName,
+    values: weekKeys.value.map(
+      (weekKey) => valuesByWeekAndDay.get(weekKey)?.[dayIndex] ?? 0,
+    ),
+  }));
+}
+
+const numberOfWeeks = computed(() => weekKeys.value.length);
+
+const baseConfig = computed<VueUiHeatmapConfig>(() => ({
+  userOptions: { show: false },
+  style: {
+    backgroundColor: colors.value.bg,
+    color: colors.value.textMuted,
+    layout: {
+      width: numberOfWeeks.value * 43,
+      cells: {
+        spacing: 0,
+        colors: {
+          cold: colors.value.bg,
+        },
+        selected: {
+          border: 2,
+          color: colors.value.text,
+        },
+        value: { show: false },
+      },
+      dataLabels: {
+        xAxis: {
+          show: true,
+          color: colors.value.textMuted,
+          values: weekLabels.value,
+        },
+        yAxis: {
+          color: colors.value.textMuted,
+        },
+      },
+    },
+    legend: { show: false },
+    tooltip: {
+      backgroundColor: colors.value.bg,
+      color: colors.value.text,
+      borderColor: colors.value.border,
+      backgroundOpacity: 70,
+    },
+  },
+}));
+
+function createHeatmapConfig(hotColor: string): VueUiHeatmapConfig {
+  return mergeConfigs({
+    defaultConfig: baseConfig.value,
+    userConfig: {
+      style: {
+        layout: {
+          cells: {
+            colors: {
+              hot: hotColor,
+            },
+          },
+        },
+      },
+    },
+  });
+}
+
+const heatmaps = computed(() =>
+  heatmapSeries.value.map((seriesItem) => ({
+    name: seriesItem.name,
+    color: seriesItem.color,
+    dataset: createHeatmapDataset(
+      props.data,
+      props.timestamps,
+      seriesItem.name,
+    ),
+    config: createHeatmapConfig(seriesItem.color!),
+  })),
+);
+
+function getDateFromHeatmapCell(datapoint: VueUiHeatmapDatapoint): string {
+  const xName = datapoint?.xAxisName ?? "";
+  const yName = datapoint?.yAxisName ?? "";
+  const [startLabel] = xName.split(" - ");
+
+  const weekStart = dayjs(`${startLabel} ${dayjs().year()}`, "MMM D YYYY");
+  const targetDate = weekStart.add(dayIndexes[yName] ?? 0, "day");
+
+  return targetDate.format("DD MMM (ddd)");
+}
+</script>
+
+<template>
+  <div class="mx-auto max-w-full" :style="{ width: numberOfWeeks * 30 + 'px' }">
+    <ClientOnly>
+      <VueUiHeatmap
+        v-for="heatmap in heatmaps"
+        :key="heatmap.name"
+        :dataset="heatmap.dataset"
+        :config="heatmap.config"
+      >
+        <template #tooltip="{ datapoint }">
+          <div class="mb-1" :style="{ color: colors.textMuted }">
+            {{ getDateFromHeatmapCell(datapoint) }}
+          </div>
+
+          <div class="flex flex-row gap-2 items-center">
+            <div class="h-2 w-2">
+              <svg viewBox="0 0 2 2" class="w-full h-full">
+                <circle cx="1" cy="1" r="1" :fill="heatmap.color" />
+              </svg>
+            </div>
+
+            <span>{{ heatmap.name }}</span>
+            <span :style="{ color: colors.textMuted }">{{
+              datapoint.value
+            }}</span>
+          </div>
+        </template>
+      </VueUiHeatmap>
+    </ClientOnly>
+  </div>
+</template>
+
+<style scoped>
+:deep(rect) {
+  shape-rendering: crispEdges !important;
+}
+</style>

--- a/app/components/Chart/GlobalEventsHeatmap.vue
+++ b/app/components/Chart/GlobalEventsHeatmap.vue
@@ -185,10 +185,10 @@ const heatmaps = computed(() =>
 function getDateFromHeatmapCell(datapoint: VueUiHeatmapDatapoint): string {
   const xName = datapoint?.xAxisName ?? "";
   const yName = datapoint?.yAxisName ?? "";
-  const [startLabel] = xName.split(" - ");
-
-  const weekStart = dayjs(`${startLabel} ${dayjs().year()}`, "MMM D YYYY");
-  const targetDate = weekStart.add(dayIndexes[yName] ?? 0, "day");
+  const weekIndex = weekLabels.value.indexOf(xName);
+  const weekKey = weekKeys.value[weekIndex];
+  if (!weekKey) return "";
+  const targetDate = dayjs(weekKey).add(dayIndexes[yName] ?? 0, "day");
 
   return targetDate.format("DD MMM (ddd)");
 }

--- a/app/pages/heatmap.vue
+++ b/app/pages/heatmap.vue
@@ -1,11 +1,113 @@
 <script setup lang="ts">
+import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
+
+// NOTE: The data treatment is identical to the one on /health
+// Eventually, we can just move the heatmaps there ?
+// If not, we'll make a composable to centralize data computation
+const { data } = useScan();
+
 definePageMeta({
   layout: false,
+});
+
+const rootEl = shallowRef<HTMLElement | null>(null);
+const colors = useColors(rootEl);
+
+function createChartDataset(source?: Scan[]): {
+  categories: string[];
+  dataset: VueUiStacklineDatasetItem[];
+} {
+  if (!source?.length) {
+    return {
+      categories: [],
+      dataset: [
+        {
+          name: "Organic",
+          series: [],
+          color: colors.value.greenLine,
+        },
+        {
+          name: "Mixed",
+          series: [],
+          color: colors.value.amber,
+        },
+        {
+          name: "Automation",
+          series: [],
+          color: colors.value.dangerHover,
+        },
+      ],
+    };
+  }
+
+  const categories = [...new Set(source.map((item) => item.created_at))].sort();
+
+  const sumsByDate: Record<
+    string,
+    {
+      automation: number;
+      mixed: number;
+      organic: number;
+    }
+  > = {};
+
+  categories.forEach((date) => {
+    sumsByDate[date] = {
+      automation: 0,
+      mixed: 0,
+      organic: 0,
+    };
+  });
+
+  source.forEach((item) => {
+    const dateSums = sumsByDate[item.created_at];
+
+    if (!dateSums) return;
+
+    if (item.score <= 50) {
+      dateSums.automation += 1;
+    } else if (item.score <= 70) {
+      dateSums.mixed += 1;
+    } else {
+      dateSums.organic += 1;
+    }
+  });
+
+  return {
+    categories,
+    dataset: [
+      {
+        name: "Organic",
+        series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
+        color: colors.value.greenLine,
+      },
+      {
+        name: "Mixed",
+        series: categories.map((date) => sumsByDate[date]?.mixed ?? 0),
+        color: colors.value.amber,
+      },
+      {
+        name: "Automation",
+        series: categories.map((date) => sumsByDate[date]?.automation ?? 0),
+        color: colors.value.dangerHover,
+      },
+    ],
+  };
+}
+
+const stacklineData = computed(() => createChartDataset(data.value));
+
+const dataset = computed(() => stacklineData.value.dataset);
+
+const timestamps = computed(() => {
+  if (!data.value?.length) return [];
+
+  return [...new Set(data.value.map((item) => item.created_at))].sort();
 });
 </script>
 
 <template>
   <div class="h-screen w-screen flex items-center justify-center text-3xl">
-    🔥
+    <ChartGlobalEventsHeatmap :data="dataset" :timestamps />
   </div>
 </template>


### PR DESCRIPTION
This adds heatmap charts in the /heatmap page.
The purpose is to wait and see if some patterns emerge after a few weeks.

Each category (organic, mixed, automated) has its own chart, with its own min max color system.

<img width="519" height="713" alt="image" src="https://github.com/user-attachments/assets/5d05ea5d-b74b-4b69-992a-2f7fced310a4" />
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a fully functional heatmap visualization page displaying Organic, Mixed, and Automation events with interactive tooltips and date-based data aggregation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/117)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->