### PR TITLE
fix: hide chart when dataset is empty

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -11,6 +11,7 @@ import { useElementSize } from "@vueuse/core";
 import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
 import { useColors } from "~/composables/useColors";
 import { identityConfig } from "@unveil/identity";
+import { VueUiIcon } from "vue-data-ui/vue-ui-icon";
 
 import("vue-data-ui/style.css");
 
@@ -195,6 +196,12 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
 }
 
 const datasetLine = computed(() => createLineDataset(props.events));
+const isEmpty = computed(
+  () =>
+    datasetLine.value
+      .flatMap((d) => d.series)
+      .reduce((a, b) => (a ?? 0) + (b ?? 0), 0) === 0,
+);
 
 const maxValBetweenDatasetAndThresholds = computed(() => {
   const maxDataset = Math.max(
@@ -289,7 +296,7 @@ const configLine = computed<VueUiXyConfig>(() => ({
 <template>
   <ClientOnly>
     <VueUiXy
-      v-if="hasEnoughDays"
+      v-if="hasEnoughDays && !isEmpty"
       ref="chartLineRef"
       :dataset="datasetLine"
       :config="configLine"
@@ -351,6 +358,15 @@ const configLine = computed<VueUiXyConfig>(() => ({
         </div>
       </template>
     </VueUiXy>
+    <div
+      v-if="isEmpty"
+      class="w-full h-64 flex place-items-center justify-center"
+    >
+      <div class="flex flex-col items-center gap-4">
+        <VueUiIcon name="chartSparkline" :stroke="colors.text" />
+        <p class="text-gh-muted">No recent events</p>
+      </div>
+    </div>
   </ClientOnly>
 </template>
 

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -360,11 +360,11 @@ const configLine = computed<VueUiXyConfig>(() => ({
     </VueUiXy>
     <div
       v-if="isEmpty"
-      class="w-full h-64 flex place-items-center justify-center"
+      class="w-full h-40 flex place-items-center justify-center"
     >
       <div class="flex flex-col items-center gap-4">
         <VueUiIcon name="chartSparkline" :stroke="colors.text" />
-        <p class="text-gh-muted">No recent events</p>
+        <p class="text-gh-muted">No activity to display</p>
       </div>
     </div>
   </ClientOnly>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -11,7 +11,9 @@ export default defineNuxtConfig({
         "dayjs", // CJS
         "@unveil/identity",
         "@vueuse/core",
-        "vue-data-ui/vue-ui-scatter",
+        "vue-data-ui/vue-ui-xy",
+        "vue-data-ui/vue-ui-heatmap",
+        "vue-data-ui/vue-ui-icon",
       ],
     },
   },


### PR DESCRIPTION
Resolves #118 

Displays a chart icon with a message when the dataset is empty

<img width="324" height="227" alt="image" src="https://github.com/user-attachments/assets/85a038bf-72b4-402d-b3e7-711fe96aefd2" />

The icon is part of the vue-data-ui library.
Other icons available: https://vue-data-ui.graphieros.com/docs#vue-ui-icon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The account events timeline now shows a centered "No activity to display" message when there is no activity, instead of rendering an empty chart.

* **Chores**
  * Build configuration updated so additional UI chart and icon components are available at runtime.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/119)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/119)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->