### PR TITLE
fix: incorrect padding offset on health chart

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -37,7 +37,17 @@ const dataset = computed<VueUiXyDatasetItem[]>(() =>
 
 const tooltipPosition = useChartTooltipPosition(chartRef);
 
-const viewBoxOffset = computed(() => -props.width * 0.075);
+const progressionLabelOffsetX = 6; // compensate hard-coded internal in VueUiXy
+
+const viewBoxPadding = computed(() => {
+  const maxSeries = props.timestamps.length;
+  if (maxSeries <= 1) return { left: 0, right: 0 };
+  const halfVueUiXyDatapointStep = props.width / (2 * (maxSeries - 1));
+  return {
+    left: -halfVueUiXyDatapointStep,
+    right: -halfVueUiXyDatapointStep - progressionLabelOffsetX,
+  };
+});
 
 const config = computed<VueUiXyConfig>(() => ({
   useCssAnimation: false,
@@ -51,14 +61,17 @@ const config = computed<VueUiXyConfig>(() => ({
     width: props.width,
     height: props.height,
     padding: {
-      left: viewBoxOffset.value,
-      right: viewBoxOffset.value,
+      left: viewBoxPadding.value.left,
+      right: viewBoxPadding.value.right,
     },
     grid: {
       position: "middle",
       stroke: "transparent",
       labels: {
         show: false,
+        yAxis: {
+          crosshairSize: 0,
+        },
         xAxisLabels: {
           show: false,
           values: props.timestamps,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.19.5",
+        "vue-data-ui": "^3.19.7",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13531,9 +13531,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.19.5",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.5.tgz",
-      "integrity": "sha512-mLfiveMh4p3/xeXLB/30IkO1b8tc8wJLBv2Ajo32kJTPgpEO814Z8tZS4BRKGJsuFtkGOt6FZVD/rgslM+xRiQ==",
+      "version": "3.19.7",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.7.tgz",
+      "integrity": "sha512-4ZpYg5SDpo11EyV59jvwa/cAFe6Oiz+LtwcAC60LTBANZO6x8F1GLo0i22TuZo3kKOxXN5TQFbVfwIQhg62i5w==",
       "license": "MIT",
       "peerDependencies": {
         "jspdf": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.19.5",
+    "vue-data-ui": "^3.19.7",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the incorrect offset calculation on the health chart, which was overflowing the first and last datapoints more and more after each day (with the current number of days to this date, the first and last datapoints were basically impossible to hover). The offset now adapts to hardcoded internals of the chart component.

Other: bump vue-data-ui to latest (no impact on our usage here, just staying fresh)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic padding calculations for chart rendering based on data size
  * Updated chart grid crosshair configuration for better visual consistency

* **Chores**
  * Updated data visualization library dependency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/121)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->