### PR TITLE
feat: show icons when threhsolds are reached, remove threhsold lines

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -12,6 +12,7 @@ import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
 import { useColors } from "~/composables/useColors";
 import { identityConfig } from "@unveil/identity";
 import { VueUiIcon } from "vue-data-ui/vue-ui-icon";
+import type { VueUiXyDatasetLineItem } from "vue-data-ui/vue-ui-xy";
 
 import("vue-data-ui/style.css");
 
@@ -88,41 +89,6 @@ const eventConfig = computed(() => {
   };
 });
 
-type VueUiXyAnnotation = NonNullable<
-  NonNullable<VueUiXyConfig["chart"]>["annotations"]
->[number];
-
-/**
- * NOTE: thresholds are assumed to have different values for each metric.
- * If 2 metrics share the same threshold, then you might consider merging them into a single one.
- */
-const thresholds = computed<VueUiXyAnnotation[]>(() => {
-  return Object.values(eventConfig.value)
-    .filter((kpi) => selectedLegendItems.value.includes(kpi.name))
-    .filter((kpi) => !!kpi.threshold)
-    .map((kpi) => ({
-      show: true,
-      yAxis: {
-        yTop: kpi.threshold,
-        label: {
-          position: "start", // or 'end', to alternate if needed to prevent overlap between contiguous labels
-          text: `${kpi.name} (${kpi.threshold})`,
-          offsetX: -12, // if position == 'end', needs to be adapted
-          offsetY: kpi.labelOffsetY,
-          fontSize: 16,
-          backgroundColor: "transparent",
-          color: kpi.color,
-          border: { stroke: "transparent" },
-        },
-        line: {
-          stroke: kpi.color,
-          strokeWidth: 2,
-          strokeDasharray: 6,
-        },
-      },
-    }));
-});
-
 function isGitHubEventType(type: string | null): type is GitHubEventType {
   return type !== null && githubEventTypes.includes(type as GitHubEventType);
 }
@@ -175,6 +141,7 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
         smooth: true,
         name: config.name,
         color: config.color,
+        threshold: config.threshold,
         series: days.map((day) => counts[eventType][day] || 0),
       };
     });
@@ -203,16 +170,12 @@ const isEmpty = computed(
       .reduce((a, b) => (a ?? 0) + (b ?? 0), 0) === 0,
 );
 
-const maxValBetweenDatasetAndThresholds = computed(() => {
-  const maxDataset = Math.max(
+const maxValue = computed(() => {
+  return Math.max(
     ...datasetLine.value
       .filter((s) => selectedLegendItems.value.includes(s.name))
       .flatMap((d) => d.series.map((v) => v ?? 0)),
   );
-  const maxThreshold = Math.max(
-    ...thresholds.value.map((t) => t.yAxis?.yTop ?? 0),
-  );
-  return Math.max(maxDataset, maxThreshold, 1);
 });
 
 const timestamps = computed<number[]>(() => {
@@ -240,7 +203,9 @@ const configLine = computed<VueUiXyConfig>(() => ({
     userOptions: { show: false },
     backgroundColor: "transparent",
     color: colors.value.textMuted,
-    annotations: thresholds.value,
+    padding: {
+      top: 24, // leave space in case of alert icon on max chart value
+    },
     highlighter: {
       useLine: true,
       color: colors.value.textMuted,
@@ -251,7 +216,7 @@ const configLine = computed<VueUiXyConfig>(() => ({
       labels: {
         show: false,
         yAxis: {
-          scaleMax: maxValBetweenDatasetAndThresholds.value,
+          scaleMax: maxValue.value,
           useNiceScale: false,
         },
         xAxisLabels: {
@@ -291,6 +256,39 @@ const configLine = computed<VueUiXyConfig>(() => ({
     },
   },
 }));
+
+type Datapoints = Array<VueUiXyDatasetLineItem & { threshold: number }>;
+
+type PlotAlert = {
+  name: string;
+  coordinates: Array<{
+    x: number;
+    y: number;
+    absoluteIndex: number;
+    isAlert: boolean;
+  }>;
+};
+
+function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
+  return data
+    .filter((d) => d.threshold !== null && d.threshold !== undefined)
+    .map((d) => {
+      return {
+        name: d.name,
+        coordinates: d.plots!.map((plot, index) => {
+          const absoluteIndex = index + zoomOffset;
+
+          return {
+            ...plot,
+            absoluteIndex,
+            isAlert:
+              d.absoluteValues[absoluteIndex] !== null &&
+              d.absoluteValues[absoluteIndex]! >= d.threshold,
+          };
+        }),
+      };
+    });
+}
 </script>
 
 <template>
@@ -357,6 +355,27 @@ const configLine = computed<VueUiXyConfig>(() => ({
           </button>
         </div>
       </template>
+
+      <!-- Custom SVG content ⚡ -->
+      <template #svg="{ svg }">
+        <g
+          v-for="alerts in alertIcons(svg.data as Datapoints, svg.slicer.start)"
+          :key="alerts.name"
+        >
+          <template
+            v-for="plot in alerts.coordinates"
+            :key="`${alerts.name}-${plot.absoluteIndex}`"
+          >
+            <path
+              v-if="plot.isAlert"
+              class="svg-element-transition"
+              :d="`M ${plot.x - 4} ${plot.y - 6} l 12 -17 l -6 0 l 3 -13 l -11 17 l 6 0 l -4 13`"
+              :fill="colors.amber"
+              :stroke="colors.bg"
+            />
+          </template>
+        </g>
+      </template>
     </VueUiXy>
     <div
       v-if="isEmpty"
@@ -379,7 +398,6 @@ const configLine = computed<VueUiXyConfig>(() => ({
 :deep(.vue-data-ui-component .serie_line_1 path),
 :deep(.vue-data-ui-component .serie_line_2 path),
 :deep(.vue-data-ui-component .serie_line_3 path),
-.svg-element-transition,
 :deep(.vdui-shape-circle) {
   transition: all 0.5s var(--super-ease-out) !important;
 }
@@ -389,7 +407,6 @@ const configLine = computed<VueUiXyConfig>(() => ({
   :deep(.vue-data-ui-component .serie_line_1 path),
   :deep(.vue-data-ui-component .serie_line_2 path),
   :deep(.vue-data-ui-component .serie_line_3 path),
-  .svg-element-transition,
   :deep(.vdui-shape-circle) {
     transition: none !important;
   }

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -171,11 +171,10 @@ const isEmpty = computed(
 );
 
 const maxValue = computed(() => {
-  return Math.max(
-    ...datasetLine.value
-      .filter((s) => selectedLegendItems.value.includes(s.name))
-      .flatMap((d) => d.series.map((v) => v ?? 0)),
-  );
+  const values = datasetLine.value
+    .filter((s) => selectedLegendItems.value.includes(s.name))
+    .flatMap((d) => d.series.map((v) => v ?? 0));
+  return values.length ? Math.max(...values) : 0;
 });
 
 const timestamps = computed<number[]>(() => {
@@ -289,6 +288,24 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
       };
     });
 }
+
+function getSeriesThreshold(seriesName: string): number | null {
+  const datasetItem = datasetLine.value.find(
+    (item) => item.name === seriesName,
+  );
+  if (!datasetItem || !("threshold" in datasetItem)) return null;
+  return datasetItem.threshold as number | null;
+}
+
+function isTooltipAlert(series: {
+  name: string;
+  value: number | null;
+}): boolean {
+  const threshold = getSeriesThreshold(series.name);
+  return (
+    threshold !== null && series.value !== null && series.value >= threshold
+  );
+}
 </script>
 
 <template>
@@ -316,7 +333,7 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
       </template>
 
       <!-- Custom tooltip -->
-      <template #tooltip="{ datapoint, timeLabel }">
+      <template #tooltip="{ datapoint, timeLabel, seriesIndex }">
         <div class="flex flex-col">
           <div class="mb-1">{{ timeLabel.text }}</div>
           <div
@@ -331,6 +348,18 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
             </div>
             <span :style="{ color: colors.textMuted }">{{ series.name }}</span>
             <span>{{ series.value }}</span>
+            <svg
+              v-if="isTooltipAlert(series)"
+              viewBox="0 0 30 30"
+              class="w-5 h-5"
+              aria-hidden="true"
+            >
+              <path
+                d="M 2 30 L 14 13 L 8 13 L 11 0 L 0 17 L 6 17 L 2 30"
+                :fill="colors.amber"
+                :stroke="colors.bg"
+              />
+            </svg>
           </div>
         </div>
       </template>


### PR DESCRIPTION
This removes the threshold lines from the account timeline chart, and displays icons above datapoints that actually exceed the threshold:

<img width="788" height="484" alt="image" src="https://github.com/user-attachments/assets/1f0a8dcf-2c55-4b9f-83cf-b35b1570723e" />

Icons will be displayed above exceeding datapoints for the forks and PR series. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Updated threshold alert rendering to use custom SVG icons for better visibility and clarity.
  * Improved chart scale calculation to focus on dataset values only.
  * Adjusted chart layout spacing for optimal icon display.

* **Style**
  * Removed certain CSS transition effects for smoother, cleaner visual rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/123)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->