### PR TITLE
fix: use hour granularity for 2 days or less on account chart

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -26,6 +26,8 @@ onMounted(async () => {
   rootEl.value = document.documentElement;
 });
 
+const locale = computed(() => "en"); // in case i18n is implemented in the future
+
 const colors = useColors(rootEl);
 
 const metrics = ["Forks", "New branches", "Pull requests", "Total"];
@@ -100,7 +102,60 @@ const eventDays = computed(() => {
   ).sort();
 });
 
+const usesHourlyGranularity = computed<boolean>(
+  () => eventDays.value.length <= 2,
+);
+
+function roundToClosestHour(date: Date): Date {
+  const rounded = new Date(date);
+  if (rounded.getUTCMinutes() >= 30) {
+    rounded.setUTCHours(rounded.getUTCHours() + 1);
+  }
+  rounded.setUTCMinutes(0, 0, 0);
+  return rounded;
+}
+
+function getCompleteHourRange(events: GitHubEvent[]): string[] {
+  const timestamps = events
+    .filter((event) => event.created_at && isGitHubEventType(event.type))
+    .map((event) => roundToClosestHour(new Date(event.created_at!)).getTime())
+    .sort((a, b) => a - b);
+
+  const firstTimestamp = timestamps[0];
+  const lastTimestamp = timestamps[timestamps.length - 1];
+
+  if (firstTimestamp === undefined || lastTimestamp === undefined) return [];
+
+  const start = new Date(firstTimestamp);
+  const end = new Date(lastTimestamp);
+  const hours: string[] = [];
+  const cursor = new Date(start);
+
+  while (cursor.getTime() <= end.getTime()) {
+    hours.push(cursor.toISOString().slice(0, 13));
+    cursor.setUTCHours(cursor.getUTCHours() + 1);
+  }
+
+  return hours;
+}
+
+const timeLabels = computed<string[]>(() => {
+  return usesHourlyGranularity.value
+    ? getCompleteHourRange(props.events)
+    : getCompleteDayRange(eventDays.value);
+});
+
 const hasEnoughDays = computed<boolean>(() => eventDays.value.length > 1);
+
+const hasEnoughHours = computed<boolean>(() => {
+  return !usesHourlyGranularity.value || timeLabels.value.length > 1;
+});
+
+const hasEnoughDataPoints = computed<boolean>(() => {
+  return usesHourlyGranularity.value
+    ? hasEnoughHours.value
+    : hasEnoughDays.value;
+});
 
 const activeGitHubEventTypes = computed(() => {
   return githubEventTypes.filter(
@@ -109,8 +164,6 @@ const activeGitHubEventTypes = computed(() => {
 });
 
 function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
-  const days = getCompleteDayRange(eventDays.value);
-
   const counts: Record<GitHubEventType, Record<string, number>> = {
     PullRequestEvent: {},
     CreateEvent: {},
@@ -119,19 +172,20 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
   };
 
   for (const event of events) {
-    if (!event.created_at || !isGitHubEventType(event.type)) {
-      continue;
-    }
+    if (!event.created_at || !isGitHubEventType(event.type)) continue;
 
-    const day = event.created_at.slice(0, 10);
+    const label = usesHourlyGranularity.value
+      ? roundToClosestHour(new Date(event.created_at!))
+          .toISOString()
+          .slice(0, 13)
+      : event.created_at.slice(0, 10);
 
-    counts[event.type][day] = (counts[event.type][day] || 0) + 1;
+    counts[event.type][label] = (counts[event.type][label] || 0) + 1;
   }
 
   const individualEvents: VueUiXyDatasetItem[] =
     activeGitHubEventTypes.value.map((eventType) => {
       const config = eventConfig.value[eventType];
-
       return {
         type: "line",
         useArea: true,
@@ -139,7 +193,7 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
         name: config.name,
         color: config.color,
         threshold: config.threshold,
-        series: days.map((day) => counts[eventType][day] || 0),
+        series: timeLabels.value.map((label) => counts[eventType][label] || 0),
       };
     });
 
@@ -149,7 +203,7 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
     smooth: true,
     name: "Combined activity",
     color: colors.value.text! + 25, // hex + alpha
-    series: days.map((_, index) => {
+    series: timeLabels.value.map((_, index) => {
       return individualEvents.reduce((total, event) => {
         return total + Number(event.series[index]);
       }, 0);
@@ -175,9 +229,53 @@ const maxValue = computed(() => {
 });
 
 const timestamps = computed<number[]>(() => {
-  return getCompleteDayRange(eventDays.value).map((day) =>
-    new Date(day).getTime(),
-  );
+  return timeLabels.value.map((label) => {
+    return usesHourlyGranularity.value
+      ? new Date(`${label}:00:00.000Z`).getTime()
+      : new Date(label).getTime();
+  });
+});
+
+const xAxisLabelValues = computed<string[]>(() => {
+  const dates = timeLabels.value.map((label) => {
+    return usesHourlyGranularity.value
+      ? new Date(`${label}:00:00.000Z`)
+      : new Date(label);
+  });
+
+  const hasMidnight = dates.some((date) => {
+    return date.getUTCHours() === 0 && date.getUTCMinutes() === 0;
+  });
+
+  return dates.map((date, index) => {
+    if (!usesHourlyGranularity.value) {
+      return new Intl.DateTimeFormat(locale.value, {
+        timeZone: "UTC",
+        day: "2-digit",
+        month: "short",
+      }).format(date);
+    }
+
+    const isMidnight = date.getUTCHours() === 0 && date.getUTCMinutes() === 0;
+    const shouldShowDay = isMidnight || (!hasMidnight && index === 0);
+
+    return new Intl.DateTimeFormat(locale.value, {
+      timeZone: "UTC",
+      ...(shouldShowDay
+        ? {
+            day: "2-digit",
+            month: "short",
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          }
+        : {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          }),
+    }).format(date);
+  });
 });
 
 const tooltipPositionLine = useChartTooltipPosition(chartLineRef);
@@ -218,25 +316,12 @@ const configLine = computed<VueUiXyConfig>(() => ({
         xAxisLabels: {
           show: true,
           color: colors.value.textMuted,
-          values: timestamps.value,
-          showOnlyAtModulo: true,
+          values: xAxisLabelValues.value,
+          showOnlyAtModulo: !usesHourlyGranularity.value,
           modulo: 12,
           rotation: -30,
-          autoRotate: {
-            enable: false,
-          },
-          datetimeFormatter: {
-            enable: true,
-            useUTC: true,
-            locale: "en",
-            options: {
-              year: "dd MMM",
-              month: "dd MMM",
-              day: "dd MMM",
-              minute: "dd MMM",
-              second: "dd MMM",
-            },
-          },
+          autoRotate: { enable: false },
+          datetimeFormatter: { enable: false },
         },
       },
     },
@@ -303,12 +388,33 @@ function isTooltipAlert(series: {
     threshold !== null && series.value !== null && series.value >= threshold
   );
 }
+
+const tooltipTimeLabels = computed<string[]>(() => {
+  return timestamps.value.map((timestamp) => {
+    return new Intl.DateTimeFormat(locale.value, {
+      timeZone: "UTC",
+      day: "2-digit",
+      month: "short",
+      ...(usesHourlyGranularity.value
+        ? {
+            hour: "2-digit",
+            minute: "2-digit",
+            hour12: false,
+          }
+        : {}),
+    }).format(timestamp);
+  });
+});
+
+function getTooltipTimeLabel(index: number): string {
+  return tooltipTimeLabels.value[index] ?? "";
+}
 </script>
 
 <template>
   <ClientOnly>
     <VueUiXy
-      v-if="hasEnoughDays && !isEmpty"
+      v-if="hasEnoughDataPoints && !isEmpty"
       ref="chartLineRef"
       :dataset="datasetLine"
       :config="configLine"
@@ -332,7 +438,11 @@ function isTooltipAlert(series: {
       <!-- Custom tooltip -->
       <template #tooltip="{ datapoint, timeLabel, seriesIndex }">
         <div class="flex flex-col">
-          <div class="mb-1">{{ timeLabel.text }}</div>
+          <div class="mb-1">
+            <div class="mb-1">
+              {{ getTooltipTimeLabel(seriesIndex) }}
+            </div>
+          </div>
           <div
             class="flex flex-row gap-2 items-center"
             v-for="series in datapoint"

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -436,7 +436,7 @@ function getTooltipTimeLabel(index: number): string {
       </template>
 
       <!-- Custom tooltip -->
-      <template #tooltip="{ datapoint, timeLabel, seriesIndex }">
+      <template #tooltip="{ datapoint, seriesIndex }">
         <div class="flex flex-col">
           <div class="mb-1">
             {{ getTooltipTimeLabel(seriesIndex) }}

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -102,9 +102,13 @@ const eventDays = computed(() => {
   ).sort();
 });
 
-const usesHourlyGranularity = computed<boolean>(
-  () => eventDays.value.length <= 2,
-);
+const completeDayLabels = computed<string[]>(() => {
+  return getCompleteDayRange(eventDays.value);
+});
+
+const usesHourlyGranularity = computed<boolean>(() => {
+  return completeDayLabels.value.length <= 2;
+});
 
 function roundToClosestHour(date: Date): Date {
   const rounded = new Date(date);
@@ -142,7 +146,7 @@ function getCompleteHourRange(events: GitHubEvent[]): string[] {
 const timeLabels = computed<string[]>(() => {
   return usesHourlyGranularity.value
     ? getCompleteHourRange(props.events)
-    : getCompleteDayRange(eventDays.value);
+    : completeDayLabels.value;
 });
 
 const hasEnoughDays = computed<boolean>(() => eventDays.value.length > 1);

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -439,9 +439,7 @@ function getTooltipTimeLabel(index: number): string {
       <template #tooltip="{ datapoint, timeLabel, seriesIndex }">
         <div class="flex flex-col">
           <div class="mb-1">
-            <div class="mb-1">
-              {{ getTooltipTimeLabel(seriesIndex) }}
-            </div>
+            {{ getTooltipTimeLabel(seriesIndex) }}
           </div>
           <div
             class="flex flex-row gap-2 items-center"

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -148,7 +148,7 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
     useArea: true,
     smooth: true,
     name: "Combined activity",
-    color: colors.value.borderLight,
+    color: colors.value.text! + 25, // hex + alpha
     series: days.map((_, index) => {
       return individualEvents.reduce((total, event) => {
         return total + Number(event.series[index]);


### PR DESCRIPTION
This shows the account timeline chart with an hourly granularity when the number of days is <= 2, and ensures the analysis is more precise in this case.

The day is also shown in the label at midnight (or if there is no midnight, on the first label).

<img width="826" height="534" alt="image" src="https://github.com/user-attachments/assets/71d02132-e76f-4a9c-87ed-ac03dd257c15" />

Also, this adds an alpha to the hex color of the total line, so it does not cover other series when they share the same path.
