### PR TITLE
chore: bump vue-data-ui from 3.19.7 to 3.19.8

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -306,10 +306,11 @@ const configLine = computed<VueUiXyConfig>(() => ({
     },
     highlighter: {
       useLine: true,
+      opacity: 0,
       color: colors.value.textMuted,
     },
     grid: {
-      position: "middle",
+      position: "start",
       stroke: "transparent",
       labels: {
         show: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.19.7",
+        "vue-data-ui": "^3.19.8",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13991,9 +13991,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.19.7",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.7.tgz",
-      "integrity": "sha512-4ZpYg5SDpo11EyV59jvwa/cAFe6Oiz+LtwcAC60LTBANZO6x8F1GLo0i22TuZo3kKOxXN5TQFbVfwIQhg62i5w==",
+      "version": "3.19.8",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.8.tgz",
+      "integrity": "sha512-jgJQijh1McxKyj9G71ddFEO0OyZ+vbN7GB9lcNxmwSlgEZqRpj3mEWWpYun7G61Ow4dMYj/xbWIsBxuPqaB4wg==",
       "license": "MIT",
       "peerDependencies": {
         "jspdf": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.19.7",
+    "vue-data-ui": "^3.19.8",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This update now allows to use the `chart.grid.position:start` attribute, that makes the chart take the full width even when there are only a few datapoints to show.

<img width="783" height="705" alt="image" src="https://github.com/user-attachments/assets/f4ab1eec-15a3-498a-9c43-585b23304b67" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the account events timeline chart display by refining highlighter visibility behavior and adjusting grid layout positioning for better visual clarity.

* **Chores**
  * Updated charting library dependency to the latest stable version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->