### PR TITLE
fix: raise lttb threshold

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -285,6 +285,9 @@ const xAxisLabelValues = computed<string[]>(() => {
 const tooltipPositionLine = useChartTooltipPosition(chartLineRef);
 
 const configLine = computed<VueUiXyConfig>(() => ({
+  downsample: {
+    threshold: 5000,
+  },
   useCssAnimation: false,
   line: {
     useGradient: false,

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -51,6 +51,9 @@ const viewBoxPadding = computed(() => {
 
 const config = computed<VueUiXyConfig>(() => ({
   useCssAnimation: false,
+  downsample: {
+    threshold: 5000,
+  },
   line: {
     radius: Number.MIN_VALUE, // bug in the lib, 0 does not work
   },


### PR DESCRIPTION
This raises the threshold above which the line chart triggers its [lttb](https://dev.to/crate/advanced-downsampling-with-the-lttb-algorithm-3okh) downsampling optimization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized chart rendering performance for datasets with large event volumes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->