### PR TITLE
fix: limit chart data to last 90 days

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -88,18 +88,28 @@ const eventConfig = computed(() => {
   };
 });
 
+const dayRangeLimit = 90;
+
 function isGitHubEventType(type: string | null): type is GitHubEventType {
   return type !== null && githubEventTypes.includes(type as GitHubEventType);
 }
 
 const eventDays = computed(() => {
-  return Array.from(
+  const days = Array.from(
     new Set(
       props.events
         .filter((event) => event.created_at && isGitHubEventType(event.type))
         .map((event) => event.created_at!.slice(0, 10)),
     ),
   ).sort();
+
+  const lastDay = days.at(-1);
+  if (!lastDay) return [];
+
+  const startDate = new Date(`${lastDay}T00:00:00.000Z`);
+  startDate.setUTCDate(startDate.getUTCDate() - dayRangeLimit + 1);
+  const startDay = startDate.toISOString().slice(0, 10);
+  return days.filter((day) => day >= startDay);
 });
 
 const completeDayLabels = computed<string[]>(() => {

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -94,11 +94,31 @@ function isGitHubEventType(type: string | null): type is GitHubEventType {
   return type !== null && githubEventTypes.includes(type as GitHubEventType);
 }
 
+const activeGitHubEventTypes = [
+  "PullRequestEvent",
+  "CreateEvent",
+  "ForkEvent",
+] as const satisfies readonly GitHubEventType[];
+
+type ActiveGitHubEventType = Exclude<GitHubEventType, "IssueCommentEvent">;
+
+function isActiveGitHubEventType(
+  type: GitHubEventType,
+): type is ActiveGitHubEventType {
+  return activeGitHubEventTypes.includes(type as ActiveGitHubEventType);
+}
+
 const eventDays = computed(() => {
   const days = Array.from(
     new Set(
       props.events
-        .filter((event) => event.created_at && isGitHubEventType(event.type))
+        .filter((event) => {
+          return (
+            event.created_at &&
+            isGitHubEventType(event.type) &&
+            isActiveGitHubEventType(event.type)
+          );
+        })
         .map((event) => event.created_at!.slice(0, 10)),
     ),
   ).sort();
@@ -110,6 +130,19 @@ const eventDays = computed(() => {
   startDate.setUTCDate(startDate.getUTCDate() - dayRangeLimit + 1);
   const startDay = startDate.toISOString().slice(0, 10);
   return days.filter((day) => day >= startDay);
+});
+
+const limitedEvents = computed(() => {
+  const firstDay = eventDays.value[0];
+  if (!firstDay) return [];
+  return props.events.filter((event) => {
+    return (
+      event.created_at &&
+      isGitHubEventType(event.type) &&
+      isActiveGitHubEventType(event.type) &&
+      event.created_at.slice(0, 10) >= firstDay
+    );
+  });
 });
 
 const completeDayLabels = computed<string[]>(() => {
@@ -155,7 +188,7 @@ function getCompleteHourRange(events: GitHubEvent[]): string[] {
 
 const timeLabels = computed<string[]>(() => {
   return usesHourlyGranularity.value
-    ? getCompleteHourRange(props.events)
+    ? getCompleteHourRange(limitedEvents.value)
     : completeDayLabels.value;
 });
 
@@ -169,12 +202,6 @@ const hasEnoughDataPoints = computed<boolean>(() => {
   return usesHourlyGranularity.value
     ? hasEnoughHours.value
     : hasEnoughDays.value;
-});
-
-const activeGitHubEventTypes = computed(() => {
-  return githubEventTypes.filter(
-    (eventType) => eventType !== "IssueCommentEvent",
-  );
 });
 
 function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
@@ -197,8 +224,8 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
     counts[event.type][label] = (counts[event.type][label] || 0) + 1;
   }
 
-  const individualEvents: VueUiXyDatasetItem[] =
-    activeGitHubEventTypes.value.map((eventType) => {
+  const individualEvents: VueUiXyDatasetItem[] = activeGitHubEventTypes.map(
+    (eventType) => {
       const config = eventConfig.value[eventType];
       return {
         type: "line",
@@ -209,7 +236,8 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
         threshold: config.threshold,
         series: timeLabels.value.map((label) => counts[eventType][label] || 0),
       };
-    });
+    },
+  );
 
   const totalEvents: VueUiXyDatasetItem = {
     type: "line",
@@ -227,7 +255,8 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
   return [...individualEvents, totalEvents];
 }
 
-const datasetLine = computed(() => createLineDataset(props.events));
+const datasetLine = computed(() => createLineDataset(limitedEvents.value));
+
 const isEmpty = computed(
   () =>
     datasetLine.value


### PR DESCRIPTION
This limits the chart dataset to the last 90 days, to avoid long streaks of empty days when a set contains a very old date.

| Before | After |
|-|-|
|<img width="400"  alt="image" src="https://github.com/user-attachments/assets/a7a73efa-afed-4afb-8ee2-69da18bdc83e" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/b72f2b77-4213-4b79-a80d-d1cbbc370610" />|

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account events timeline now shows only the most recent 90 days of activity.
  * Timeline labels and chart data use hourly granularity within that 90-day window for clearer recent activity trends.
  * Events are filtered to active event types so the chart focuses on relevant activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->