### PR TITLE
feat: health response evolution chart

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -260,14 +260,14 @@ const datasetLine = computed(() => createLineDataset(limitedEvents.value));
 const isEmpty = computed(
   () =>
     datasetLine.value
-      .flatMap((d) => d.series)
+      .flatMap((d) => d.series as (number | null)[])
       .reduce((a, b) => (a ?? 0) + (b ?? 0), 0) === 0,
 );
 
 const maxValue = computed(() => {
   const values = datasetLine.value
     .filter((s) => selectedLegendItems.value.includes(s.name))
-    .flatMap((d) => d.series.map((v) => v ?? 0));
+    .flatMap((d) => d.series.map((v) => v ?? 0)) as number[];
   return values.length ? Math.max(...values) : 0;
 });
 

--- a/app/components/Chart/FeaturedPackageHealthRanking.vue
+++ b/app/components/Chart/FeaturedPackageHealthRanking.vue
@@ -108,6 +108,7 @@ const dataset = computed<VueUiHorizontalBarDatasetItem[]>(() => {
 </script>
 <template>
   <div class="flex flex-col w-full">
+    <!-- FIXME: that crappy date selector would need some love -->
     <CommonDateSelector :source="healthData" @select-date="setSelectedDate">
       <template #label> Choose a date </template>
     </CommonDateSelector>

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+import { computed, shallowRef } from "vue";
+import { VueUiXy, type VueUiXyConfig } from "vue-data-ui/vue-ui-xy";
+import "vue-data-ui/style.css";
+
+const { data } = useEcosystemHealth();
+const rootEl = shallowRef<HTMLElement | null>(null);
+const colors = useColors(rootEl);
+
+const scoreBounds = shallowRef<ScoreBounds>([0, 50]);
+
+const selectedRangeColor = computed(() => {
+  const [minScore, maxScore] = scoreBounds.value;
+  if (minScore === 0 && maxScore === 50) {
+    return colors.value.danger;
+  }
+  if (minScore === 50 && maxScore === 70) {
+    return colors.value.amber;
+  }
+  return colors.value.green;
+});
+
+const sparklines = computed(() => {
+  return getClosedPrPercentageEvolutionByRepo(
+    data.value ?? [],
+    scoreBounds.value,
+  ).map((dataset) => {
+    return dataset.map((datapoint) => ({
+      ...datapoint,
+      color: colors.value.textMuted,
+    }));
+  });
+});
+
+const config = computed<VueUiXyConfig>(() => ({
+  useCssAnimation: false,
+  chart: {
+    userOptions: { show: false },
+    legend: { show: false },
+    tooltip: { show: false },
+    highlighter: { opacity: 0 },
+    padding: {
+      top: 6,
+      left: 4,
+      right: 66,
+      bottom: 0,
+    },
+    backgroundColor: "transparent",
+    height: 100,
+    width: 450,
+    grid: {
+      position: "start",
+      stroke: "transparent",
+      labels: {
+        show: false,
+        xAxisLabels: {
+          show: false,
+        },
+        yAxis: {
+          scaleMin: 0,
+          scaleMax: 100,
+        },
+      },
+    },
+  },
+  line: {
+    radius: Number.MIN_VALUE,
+  },
+}));
+
+function getLastPlot(serie: Record<string, any>) {
+  return Array.isArray(serie?.plots) ? serie.plots.at(-1) : null;
+}
+
+function getLastPlotTransform(serie: Record<string, any>) {
+  const lastPlot = getLastPlot(serie);
+  if (!lastPlot) return "";
+  return `translate(${lastPlot.x}px, ${lastPlot.y}px)`;
+}
+
+function getLastPlotLabel(serie: Record<string, any>) {
+  const lastPlot = getLastPlot(serie);
+  const value = Number(lastPlot?.value ?? 0);
+  return `${value.toFixed(0)}%`;
+}
+</script>
+
+<template>
+  <h2 class="text-center mb-3">
+    Evolution of pull request closure rates by repository for PRs in a given
+    score range.
+  </h2>
+
+  <div class="mb-4 flex items-center justify-center gap-6">
+    <label class="font-medium">Score range</label>
+
+    <label class="flex items-center gap-2 cursor-pointer">
+      <input
+        v-model="scoreBounds"
+        type="radio"
+        :value="[0, 50]"
+        class="accent-red"
+      />
+      <span>0-50</span>
+    </label>
+
+    <label class="flex items-center gap-2 cursor-pointer">
+      <input
+        v-model="scoreBounds"
+        type="radio"
+        :value="[50, 70]"
+        class="accent-amber"
+      />
+      <span>50-70</span>
+    </label>
+
+    <label class="flex items-center gap-2 cursor-pointer">
+      <input
+        v-model="scoreBounds"
+        type="radio"
+        :value="[70, 100]"
+        class="accent-green"
+      />
+      <span>70-100</span>
+    </label>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4 max-w-[600px] mx-auto">
+    <ClientOnly v-for="chart in sparklines" :key="chart[0]?.name">
+      <div class="flex flex-col">
+        <div class="text-sm mb-1">
+          <span class="text-gh-muted">{{ chart[0]?.name.split("/")[0] }}/</span>
+          <span>{{ chart[0]?.name.split("/")[1] }}</span>
+        </div>
+
+        <div
+          class="w-full h-full border-gh-border border-l border-b rounded-bl"
+          v-if="chart[0]?.hasData"
+        >
+          <VueUiXy :dataset="chart" :config="config">
+            <template #svg="{ svg }">
+              <g
+                v-for="serie in Array.isArray(svg?.data) ? svg.data : []"
+                :key="serie.id"
+                class="last-datapoint"
+                :style="{ transform: getLastPlotTransform(serie) }"
+              >
+                <text
+                  class="value-label"
+                  text-anchor="start"
+                  dominant-baseline="middle"
+                  x="12"
+                  y="0"
+                  font-size="18"
+                  :fill="colors.text"
+                  :stroke="colors.bg"
+                  stroke-width="1"
+                  paint-order="stroke fill"
+                >
+                  {{ getLastPlotLabel(serie) }}
+                </text>
+
+                <circle
+                  class="value-plot"
+                  cx="0"
+                  cy="0"
+                  r="6"
+                  :fill="selectedRangeColor"
+                  :stroke="colors.bg"
+                  stroke-width="3"
+                />
+              </g>
+            </template>
+          </VueUiXy>
+        </div>
+        <div
+          class="v-else w-full h-full border-gh-border border-l border-b rounded-bl flex justify-center place-items-center"
+          v-else
+        >
+          <span class="text-xs text-gh-muted">No data to display</span>
+        </div>
+      </div>
+    </ClientOnly>
+  </div>
+</template>
+
+<style scoped>
+:deep(.vue-data-ui-component) {
+  --super-ease-out: cubic-bezier(0.15, 0.75, 0.35, 1);
+}
+
+:deep(.vue-data-ui-component svg:focus-visible) {
+  outline: none !important;
+}
+
+:deep(.vue-data-ui-component path),
+:deep(.last-datapoint),
+:deep(.value-label),
+:deep(.value-plot) {
+  transition: all 0.5s var(--super-ease-out) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :deep(.vue-data-ui-component path),
+  :deep(.last-datapoint),
+  :deep(.value-label),
+  :deep(.value-plot) {
+    transition: none !important;
+  }
+}
+</style>

--- a/app/pages/heatmap.vue
+++ b/app/pages/heatmap.vue
@@ -113,4 +113,7 @@ const timestamps = computed(() => {
   <div class="my-6 w-screen flex items-center justify-center text-3xl">
     <ChartFeaturedPackageHealthRanking class="max-w-150" />
   </div>
+  <div class="my-6 w-screen">
+    <ChartHealthResponseSparklines />
+  </div>
 </template>

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -200,9 +200,10 @@ export function getClosedPrPercentageByRepoUntilDate(
   untilDate: string | Date,
   options: RepoClosedPrOptions = {},
 ) {
+  const { dateKey = "created_at" } = options;
   const limitDay = getDayKey(untilDate);
   const filteredSource = source.filter((entry) => {
-    return getDayKey(entry.created_at) <= limitDay;
+    return getDayKey(String(entry[dateKey])) <= limitDay;
   });
   return getClosedPrPercentageByRepo(filteredSource, options);
 }

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -1,4 +1,5 @@
 import type { VueUiHorizontalBarDatasetItem } from "vue-data-ui/vue-ui-horizontal-bar";
+import type { VueUiXyDatasetItem } from "vue-data-ui/vue-ui-xy";
 
 export function getCompleteDayRange(days: string[]): string[] {
   if (!days.length) {
@@ -62,4 +63,186 @@ export function convertToHorizontalBarDataset(
     name,
     value: total / count,
   }));
+}
+
+// Evolution of pull request closure rates by repository for PRs in a given score range.
+
+export type ScoreBounds = [min: number, max: number];
+
+export type RepoClosedPrOptions = {
+  repoKey?: keyof EcosystemHealthItem;
+  prNumberKey?: keyof EcosystemHealthItem;
+  stateKey?: keyof EcosystemHealthItem;
+  scoreKey?: keyof EcosystemHealthItem;
+  dateKey?: keyof EcosystemHealthItem;
+  scoreBounds?: ScoreBounds;
+  openState?: string;
+  closedState?: string;
+  includeAlreadyClosed?: boolean;
+};
+
+export function getClosedPrPercentageByRepo(
+  source: EcosystemHealthItem[],
+  options: RepoClosedPrOptions = {},
+) {
+  const {
+    repoKey = "repo_name",
+    prNumberKey = "pr_number",
+    stateKey = "pr_status",
+    scoreKey = "score",
+    dateKey = "created_at",
+    scoreBounds = [0, 100],
+    openState = "open",
+    closedState = "closed",
+    includeAlreadyClosed = true,
+  } = options;
+
+  const resolvedScoreBounds: ScoreBounds = Array.isArray(scoreBounds)
+    ? scoreBounds
+    : [0, Number(scoreBounds)];
+
+  const [minScore, maxScore] = resolvedScoreBounds;
+
+  const byRepo = new Map<string, Map<number, EcosystemHealthItem[]>>();
+
+  source.forEach((entry) => {
+    const repo = String(entry[repoKey]);
+    const prNumber = Number(entry[prNumberKey]);
+
+    if (!repo || Number.isNaN(prNumber)) return;
+    if (!byRepo.has(repo)) byRepo.set(repo, new Map());
+
+    const repoMap = byRepo.get(repo);
+    if (!repoMap) return;
+    if (!repoMap.has(prNumber)) repoMap.set(prNumber, []);
+
+    const pullRequestEntries = repoMap.get(prNumber);
+    if (!pullRequestEntries) return;
+    pullRequestEntries.push(entry);
+  });
+
+  return Array.from(byRepo.entries()).map(([repo, pullRequests]) => {
+    let elligiblePrs = 0;
+    let closedPrs = 0;
+
+    pullRequests.forEach((entries) => {
+      if (!entries.length) return;
+
+      const sortedEntries = [...entries].sort((a, b) => {
+        return (
+          new Date(String(a[dateKey])).getTime() -
+          new Date(String(b[dateKey])).getTime()
+        );
+      });
+
+      const oldestEntry = sortedEntries[0];
+      if (!oldestEntry) return;
+
+      const latestEntry =
+        sortedEntries.length > 1
+          ? sortedEntries[sortedEntries.length - 1]
+          : undefined;
+
+      const oldestStatus = String(oldestEntry[stateKey]).toLowerCase();
+      const oldestScore = Number(oldestEntry[scoreKey]);
+      const isAlreadyClosed = oldestStatus === closedState;
+
+      const isEligible =
+        oldestScore >= minScore &&
+        oldestScore <= maxScore &&
+        (oldestStatus === openState ||
+          (includeAlreadyClosed && isAlreadyClosed));
+
+      if (!isEligible) return;
+
+      elligiblePrs += 1;
+
+      if (isAlreadyClosed) {
+        closedPrs += 1;
+        return;
+      }
+
+      if (!latestEntry) return;
+      const latestStatus = String(latestEntry[stateKey]).toLowerCase();
+      if (latestStatus === closedState) closedPrs += 1;
+    });
+
+    return {
+      repo,
+      elligiblePrs,
+      closedPrs,
+      percentage: elligiblePrs
+        ? Number(((closedPrs / elligiblePrs) * 100).toFixed(2))
+        : 0,
+    };
+  });
+}
+
+export function getUniqueDatesFromSource(
+  source: EcosystemHealthItem[],
+  dateKey: keyof EcosystemHealthItem = "created_at",
+) {
+  return Array.from(
+    new Set(
+      source
+        .map((entry) => {
+          const rawDate = entry[dateKey];
+          if (rawDate == null) return null;
+          return getDayKey(String(rawDate));
+        })
+        .filter((date): date is string => date !== null),
+    ),
+  ).sort();
+}
+
+export function getClosedPrPercentageByRepoUntilDate(
+  source: EcosystemHealthItem[],
+  untilDate: string | Date,
+  options: RepoClosedPrOptions = {},
+) {
+  const limitDay = getDayKey(untilDate);
+  const filteredSource = source.filter((entry) => {
+    return getDayKey(entry.created_at) <= limitDay;
+  });
+  return getClosedPrPercentageByRepo(filteredSource, options);
+}
+
+export type ClosedPrPercentageEvolutionSeries = {
+  name: string;
+  data: (number | null)[];
+};
+
+export function getClosedPrPercentageEvolutionByRepo(
+  source: EcosystemHealthItem[] = [],
+  scoreBounds: ScoreBounds = [0, 100],
+  dateKey: keyof EcosystemHealthItem = "created_at",
+): Array<Array<VueUiXyDatasetItem & { hasData: boolean }>> {
+  const dates = getUniqueDatesFromSource(source, dateKey);
+
+  const repoMap = new Map<string, (number | null)[]>();
+
+  dates.forEach((date, dateIndex) => {
+    const results = getClosedPrPercentageByRepoUntilDate(source, date, {
+      scoreBounds,
+    });
+
+    results.forEach((result) => {
+      if (!repoMap.has(result.repo)) {
+        repoMap.set(result.repo, Array(dates.length).fill(null));
+      }
+      const series = repoMap.get(result.repo);
+      if (!series) return;
+      series[dateIndex] = result.elligiblePrs > 0 ? result.percentage : null;
+    });
+  });
+
+  return Array.from(repoMap.entries()).map(([name, series]) => [
+    {
+      name,
+      series,
+      type: "line",
+      smooth: true,
+      hasData: series.some((value) => value !== null),
+    },
+  ]);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.19.8",
+        "vue-data-ui": "^3.20.11",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13991,9 +13991,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.19.8",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.19.8.tgz",
-      "integrity": "sha512-jgJQijh1McxKyj9G71ddFEO0OyZ+vbN7GB9lcNxmwSlgEZqRpj3mEWWpYun7G61Ow4dMYj/xbWIsBxuPqaB4wg==",
+      "version": "3.20.11",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.20.11.tgz",
+      "integrity": "sha512-BvK9amlFqGWF40J00guYmy4IYraDV1qrgMgKC48HGvn6HUCGw4HrAhRBr/7eRrRdMkR3ym6E77/GKLQhr1fQow==",
       "license": "MIT",
       "peerDependencies": {
         "jspdf": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.19.8",
+    "vue-data-ui": "^3.20.11",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/shared/types/ecosystem-health.ts
+++ b/shared/types/ecosystem-health.ts
@@ -3,6 +3,7 @@ export type EcosystemHealthItem = {
   user_id: number;
   score: number;
   pr_number: number;
+  pr_status: string; // FIXME: narrow down
   user_created_at: string;
   user_public_repos_count: number;
   events_count: number;


### PR DESCRIPTION
This adds charts to visualize the evolution of pr closure rates by repo for PRs in a given score range, as a measure of the health response to clanker prs.

<img width="755" height="944" alt="image" src="https://github.com/user-attachments/assets/c5b9f71d-40ae-4938-b3ed-05217c004266" />

Other:
- bump vue-data-ui to latest, with minor TS impacts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-repository PR closure-rate sparklines (with selectable score ranges) to the heatmap page.

* **Bug Fixes**
  * Improved handling of empty/null chart data to prevent incorrect empty-state and max-value calculations.

* **Chores**
  * Updated charting library dependency to a newer release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MatteoGabriele/agentscan/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->