### PR TITLE
fix: hide zoom sliders

### DIFF
--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -38,6 +38,7 @@ const config = computed<VueUiXyConfig>(() => ({
     userOptions: { show: false },
     legend: { show: false },
     tooltip: { show: false },
+    zoom: { show: false },
     highlighter: { opacity: 0 },
     padding: {
       top: 6,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.20.11",
+        "vue-data-ui": "^3.21.0",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -14004,9 +14004,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.20.11",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.20.11.tgz",
-      "integrity": "sha512-BvK9amlFqGWF40J00guYmy4IYraDV1qrgMgKC48HGvn6HUCGw4HrAhRBr/7eRrRdMkR3ym6E77/GKLQhr1fQow==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.0.tgz",
+      "integrity": "sha512-jfZhLeHa1c7t3wUbUBuz/HrgpxuvL4MC9DPPV9LlIl+qDEG/weGjXK9HBVGkkkhkArmlSa7yN2j6T+ghNSgc1Q==",
       "license": "MIT",
       "peerDependencies": {
         "jspdf": ">=3.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.20.11",
+    "vue-data-ui": "^3.21.0",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I had forgot to disable the zoom feature, which is only visible above a certain number of datapoints...
Also updated vue-data-ui to latest while I was at it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled zoom UI on health response sparkline charts for improved usability.

* **Chores**
  * Updated vue-data-ui library to the latest compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->