### PR TITLE
feat: add automation PR closure rate

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -41,16 +41,12 @@ const automatedClosureRateData = computed(() => ({
 }));
 
 const averageClosureRate = computed<string>(() => {
-  return (
-    Math.round(
-      (((automatedClosureRateData.value.series as Array<number | null>).reduce(
-        (a, b) => (a ?? 0) + (b ?? 0),
-        0,
-      ) ?? 0) /
-        (automatedClosureRateData.value.series.length || 1)) *
-        100,
-    ) + "%"
-  );
+  const values = (
+    automatedClosureRateData.value.series as Array<number | null>
+  ).filter((v): v is number => v !== null);
+  if (values.length === 0) return "0%";
+  const sum = values.reduce((a, b) => a + b, 0);
+  return Math.round(sum / values.length) + "%";
 });
 
 const dataset = computed<VueUiXyDatasetItem[]>(() => {

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -7,6 +7,7 @@ import {
 } from "vue-data-ui/vue-ui-xy";
 import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
 import { useColors } from "~/composables/useColors";
+import { getClosedPrPercentageEvolutionTotal } from "~/utils/charts";
 
 import("vue-data-ui/style.css");
 
@@ -15,6 +16,7 @@ const props = defineProps<{
   timestamps: string[];
   width: number;
   height: number;
+  rawData?: EcosystemHealthItem[];
 }>();
 
 const rootEl = shallowRef<HTMLElement | null>(null);
@@ -26,14 +28,41 @@ onMounted(async () => {
 
 const colors = useColors(rootEl);
 
-const dataset = computed<VueUiXyDatasetItem[]>(() =>
-  props.data.map((d) => ({
+const max = computed(() =>
+  Math.max(...props.data.flatMap((d) => d.series.map((d) => d ?? 0))),
+);
+
+const automatedClosureRateData = computed(() => ({
+  ...getClosedPrPercentageEvolutionTotal(props.rawData, [0, 50]),
+  scaleMin: 0,
+  scaleMax: 100,
+  color: "grey",
+  dashed: true,
+}));
+
+const averageClosureRate = computed<string>(() => {
+  return (
+    Math.round(
+      (((automatedClosureRateData.value.series as Array<number | null>).reduce(
+        (a, b) => (a ?? 0) + (b ?? 0),
+        0,
+      ) ?? 0) /
+        (automatedClosureRateData.value.series.length || 1)) *
+        100,
+    ) + "%"
+  );
+});
+
+const dataset = computed<VueUiXyDatasetItem[]>(() => {
+  const series = props.data.map((d) => ({
     ...d,
-    type: "line",
+    type: "line" as const,
     smooth: true,
     useArea: true,
-  })),
-);
+    scaleMax: max.value,
+  }));
+  return [...series, automatedClosureRateData.value];
+});
 
 const tooltipPosition = useChartTooltipPosition(chartRef);
 
@@ -74,6 +103,7 @@ const config = computed<VueUiXyConfig>(() => ({
         show: false,
         yAxis: {
           crosshairSize: 0,
+          useIndividualScale: true,
         },
         xAxisLabels: {
           show: false,
@@ -115,6 +145,7 @@ const config = computed<VueUiXyConfig>(() => ({
 
 <template>
   <ClientOnly>
+    <slot name="teleporter" v-bind="{ averageClosureRate }" />
     <VueUiXy ref="chartRef" :dataset :config>
       <template #area-gradient="{ series, id }">
         <linearGradient :id x1="0" x2="0" y1="0" y2="1">
@@ -139,7 +170,10 @@ const config = computed<VueUiXyConfig>(() => ({
               </svg>
             </div>
             <span :style="{ color: colors.text }">{{ series.name }}</span>
-            <span :style="{ color: colors.textMuted }">{{ series.value }}</span>
+            <span :style="{ color: colors.textMuted }">{{
+              series.value +
+              (series.slotAbsoluteIndex === dataset.length - 1 ? "%" : "")
+            }}</span>
           </div>
         </div>
       </template>

--- a/app/components/Chart/GlobalStatusDashboard.vue
+++ b/app/components/Chart/GlobalStatusDashboard.vue
@@ -4,7 +4,7 @@ import { useColors } from "~/composables/useColors";
 import { useElementSize } from "@vueuse/core";
 
 const props = defineProps<{
-  data: Scan[] | undefined;
+  data: EcosystemHealthItem[] | undefined;
 }>();
 
 const rootEl = shallowRef<HTMLElement | null>(null);
@@ -16,7 +16,7 @@ onMounted(async () => {
 
 const colors = useColors(rootEl);
 
-function createChartDataset(source: Scan[] = []): {
+function createChartDataset(source: EcosystemHealthItem[] = []): {
   categories: string[];
   dataset: VueUiStacklineDatasetItem[];
 } {
@@ -90,7 +90,13 @@ const { width, height } = useElementSize(chartContainer);
 <template>
   <div class="relative h-full w-full flex flex-col">
     <div class="flex-1 h-full no-chart-transition" ref="chartContainer">
-      <ChartGlobalEventsEvolution :data="dataset" :timestamps :width :height />
+      <ChartGlobalEventsEvolution
+        :data="dataset"
+        :timestamps
+        :width
+        :height
+        :raw-data="data"
+      />
     </div>
   </div>
 </template>

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -111,8 +111,9 @@ function getTooltipContent(
 ) {
   const { absoluteIndex: index } = timeLabel;
   const datapoint = series[0] as unknown as XyAugmentedSeries;
-  const elligible = datapoint?.details?.elligiblePrs[index];
-  const closed = datapoint?.details?.closedPrs[index];
+  const elligible = datapoint?.details?.elligiblePrs?.[index];
+  const closed = datapoint?.details?.closedPrs?.[index];
+  if (closed == null || elligible == null) return "";
   return `${closed} / ${elligible}`;
 }
 </script>

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import { computed, shallowRef } from "vue";
-import { VueUiXy, type VueUiXyConfig } from "vue-data-ui/vue-ui-xy";
+import {
+  VueUiXy,
+  type VueUiXyConfig,
+  type VueUiXySeries,
+  type VueUiXyTooltipSlotProps,
+} from "vue-data-ui/vue-ui-xy";
 import "vue-data-ui/style.css";
 
 const { data } = useEcosystemHealth();
@@ -27,7 +32,7 @@ const sparklines = computed(() => {
   ).map((dataset) => {
     return dataset.map((datapoint) => ({
       ...datapoint,
-      color: colors.value.textMuted,
+      color: colors.value.textTransparent,
     }));
   });
 });
@@ -37,9 +42,20 @@ const config = computed<VueUiXyConfig>(() => ({
   chart: {
     userOptions: { show: false },
     legend: { show: false },
-    tooltip: { show: false },
     zoom: { show: false },
-    highlighter: { opacity: 0 },
+    tooltip: {
+      show: true,
+      teleportTo: "#sparklines",
+      backgroundOpacity: 0,
+      color: colors.value.text,
+      borderColor: "transparent",
+    },
+    highlighter: {
+      opacity: 0,
+      useLine: true,
+      lineDasharray: 0,
+      color: selectedRangeColor.value,
+    },
     padding: {
       top: 6,
       left: 4,
@@ -84,6 +100,21 @@ function getLastPlotLabel(serie: Record<string, any>) {
   const value = Number(lastPlot?.value ?? 0);
   return `${value.toFixed(0)}%`;
 }
+
+type XyAugmentedSeries = VueUiXySeries[number] & {
+  details: { elligiblePrs: number[]; closedPrs: number[] };
+};
+
+function getTooltipContent(
+  series: VueUiXyTooltipSlotProps["series"],
+  timeLabel: VueUiXyTooltipSlotProps["timeLabel"],
+) {
+  const { absoluteIndex: index } = timeLabel;
+  const datapoint = series[0] as unknown as XyAugmentedSeries;
+  const elligible = datapoint?.details?.elligiblePrs[index];
+  const closed = datapoint?.details?.closedPrs[index];
+  return `${closed} / ${elligible}`;
+}
 </script>
 
 <template>
@@ -126,7 +157,7 @@ function getLastPlotLabel(serie: Record<string, any>) {
     </label>
   </div>
 
-  <div class="grid grid-cols-2 gap-4 max-w-[600px] mx-auto">
+  <div class="grid grid-cols-2 gap-4 max-w-[600px] mx-auto" id="sparklines">
     <ClientOnly v-for="chart in sparklines" :key="chart[0]?.name">
       <div class="flex flex-col">
         <div class="text-sm mb-1">
@@ -139,6 +170,11 @@ function getLastPlotLabel(serie: Record<string, any>) {
           v-if="chart[0]?.hasData"
         >
           <VueUiXy :dataset="chart" :config="config">
+            <template #tooltip="{ series, timeLabel }">
+              <div class="text-gh-muted">
+                {{ getTooltipContent(series, timeLabel) }}
+              </div>
+            </template>
             <template #svg="{ svg }">
               <g
                 v-for="serie in Array.isArray(svg?.data) ? svg.data : []"
@@ -190,10 +226,6 @@ function getLastPlotLabel(serie: Record<string, any>) {
   --super-ease-out: cubic-bezier(0.15, 0.75, 0.35, 1);
 }
 
-:deep(.vue-data-ui-component svg:focus-visible) {
-  outline: none !important;
-}
-
 :deep(.vue-data-ui-component path),
 :deep(.last-datapoint),
 :deep(.value-label),
@@ -208,5 +240,11 @@ function getLastPlotLabel(serie: Record<string, any>) {
   :deep(.value-plot) {
     transition: none !important;
   }
+}
+</style>
+
+<style>
+#sparklines .vue-data-ui-tooltip {
+  padding: 2px 6px !important;
 }
 </style>

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -1,11 +1,13 @@
 import {
   computed,
+  shallowRef,
   type ComputedRef,
   type Ref,
   type ShallowRef,
   unref,
+  watch,
 } from "vue";
-import { useSupported } from "@vueuse/core";
+import { usePreferredDark } from "@vueuse/core";
 
 type CssVariableSource =
   | HTMLElement
@@ -28,54 +30,44 @@ function toCamelCase(cssVariable: string): string {
 }
 
 function resolveElement(element?: CssVariableSource): HTMLElement | null {
-  if (typeof window === "undefined" || typeof document === "undefined")
+  if (typeof window === "undefined" || typeof document === "undefined") {
     return null;
+  }
+
   if (!element) return document.documentElement;
+
   const resolved = unref(element);
+
   return resolved ?? document.documentElement;
 }
 
-/**
- * Read multiple CSS custom properties at once and expose them as a reactive object.
- *
- * Each CSS variable name is normalized into a camelCase key:
- * - Leading `--` is removed
- * - kebab-case is converted to camelCase
- *
- * Example:
- * ```ts
- * useCssVariables(['--bg', '--fg-subtle'])
- * // => colors.value = { bg: '...', fgSubtle: '...' }
- * ```
- *
- * The returned values are always resolved via `getComputedStyle`, meaning the
- * effective value is returned (after cascade, theme classes, etc.).
- *
- * Reactivity behavior:
- * - Updates automatically when the observed element changes
- * - Can react to theme toggles via `watchHtmlAttributes`
- * - Can react to responsive CSS variables via `watchResize`
- *
- * @param variables - List of CSS variable names (must include the leading `--`)
- * @param options - Configuration options
- * @param options.element - Element to read variables from (defaults to `:root`)
- *
- * @returns An object containing a reactive `colors` map, keyed by camelCase names
- */
 export function useCssVariables(
   variables: readonly string[],
   options: UseCssVariableOptions = {},
 ): { colors: ComputedRef<Record<string, string>> } {
+  const recomputeToken = shallowRef(0);
+  const isPreferredDark = usePreferredDark();
+
+  const invalidateColors = () => {
+    recomputeToken.value += 1;
+  };
+
+  watch(isPreferredDark, invalidateColors);
+
   const elementComputed = computed(() => resolveElement(options.element));
 
   const colors = computed<Record<string, string>>(() => {
+    void recomputeToken.value;
+
     const element = elementComputed.value;
     if (!element) return {};
 
     const result: Record<string, string> = {};
+
     for (const variable of variables) {
       result[toCamelCase(variable)] = readCssVariable(element, variable);
     }
+
     return result;
   });
 

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -158,6 +158,10 @@ const hasEnoughData = computed(() => {
                 </span>
               </p>
             </li>
+          </ul>
+          <ul
+            class="text-center flex flex-col md:flex-row md:gap-6 items-center md:text-left w-full justify-center sm:mt-6"
+          >
             <li class="flex gap-2 items-center">
               <span
                 :class="`size-2 ${automatedPrClosure.bgColor} block rounded-full`"

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -160,7 +160,7 @@ const hasEnoughData = computed(() => {
             </li>
           </ul>
           <ul
-            class="text-center flex flex-col md:flex-row md:gap-6 items-center md:text-left w-full justify-center sm:mt-6"
+            class="text-center flex flex-col md:flex-row md:gap-6 items-center md:text-left w-full justify-center sm:mt-4"
           >
             <li class="flex gap-2 items-center">
               <span

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -91,6 +91,12 @@ const latestDayStats = computed<ClassificationStats | null>(() => {
   };
 });
 
+const automatedPrClosure = computed(() => ({
+  label: "Automation PR closure rate",
+  bgColor: "bg-gray-500",
+  percentage: getClosedPrPercentageTotal(data.value, [0, 50]) + "%",
+}));
+
 const MIN_DAY_DATA_COLLECTION = 4;
 const hasEnoughData = computed(() => {
   if (!data.value?.length) {
@@ -146,6 +152,17 @@ const hasEnoughData = computed(() => {
                   {{ latestDayStats?.[config.key].percentage }}% ({{
                     latestDayStats?.[config.key].count
                   }})
+                </span>
+              </p>
+            </li>
+            <li class="flex gap-2 items-center">
+              <span
+                :class="`size-2 ${automatedPrClosure.bgColor} block rounded-full`"
+              ></span>
+              <p class="text-sm">
+                {{ automatedPrClosure.label }}
+                <span class="text-gh-muted">
+                  {{ automatedPrClosure.percentage }}
                 </span>
               </p>
             </li>

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -94,7 +94,10 @@ const latestDayStats = computed<ClassificationStats | null>(() => {
 const automatedPrClosure = computed(() => ({
   label: "Automation PR closure rate",
   bgColor: "bg-gray-500",
-  percentage: getClosedPrPercentageTotal(data.value, [0, 50]) + "%",
+  percentage: (() => {
+    const value = getClosedPrPercentageTotal(data.value, [0, 50]);
+    return value === null ? "N/A" : `${value}%`;
+  })(),
 }));
 
 const MIN_DAY_DATA_COLLECTION = 4;

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -220,7 +220,14 @@ export function getClosedPrPercentageEvolutionByRepo(
 ): Array<Array<VueUiXyDatasetItem & { hasData: boolean }>> {
   const dates = getUniqueDatesFromSource(source, dateKey);
 
-  const repoMap = new Map<string, (number | null)[]>();
+  const repoMap = new Map<
+    string,
+    {
+      percentages: (number | null)[];
+      elligiblePrs: number[];
+      closedPrs: number[];
+    }
+  >();
 
   dates.forEach((date, dateIndex) => {
     const results = getClosedPrPercentageByRepoUntilDate(source, date, {
@@ -229,21 +236,36 @@ export function getClosedPrPercentageEvolutionByRepo(
 
     results.forEach((result) => {
       if (!repoMap.has(result.repo)) {
-        repoMap.set(result.repo, Array(dates.length).fill(null));
+        repoMap.set(result.repo, {
+          percentages: Array(dates.length).fill(null),
+          elligiblePrs: Array(dates.length).fill(0),
+          closedPrs: Array(dates.length).fill(0),
+        });
       }
-      const series = repoMap.get(result.repo);
-      if (!series) return;
-      series[dateIndex] = result.elligiblePrs > 0 ? result.percentage : null;
+
+      const repoData = repoMap.get(result.repo);
+
+      if (!repoData) return;
+
+      repoData.percentages[dateIndex] =
+        result.elligiblePrs > 0 ? result.percentage : null;
+
+      repoData.elligiblePrs[dateIndex] = result.elligiblePrs;
+      repoData.closedPrs[dateIndex] = result.closedPrs;
     });
   });
 
-  return Array.from(repoMap.entries()).map(([name, series]) => [
+  return Array.from(repoMap.entries()).map(([name, data]) => [
     {
       name,
-      series,
+      series: data.percentages,
       type: "line",
       smooth: true,
-      hasData: series.some((value) => value !== null),
+      hasData: data.percentages.some((value) => value !== null),
+      details: {
+        elligiblePrs: data.elligiblePrs,
+        closedPrs: data.closedPrs,
+      },
     },
   ]);
 }

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -247,3 +247,58 @@ export function getClosedPrPercentageEvolutionByRepo(
     },
   ]);
 }
+
+export function getClosedPrPercentageEvolutionTotal(
+  source: EcosystemHealthItem[] = [],
+  scoreBounds: ScoreBounds = [0, 100],
+  dateKey: keyof EcosystemHealthItem = "created_at",
+): VueUiXyDatasetItem {
+  const dates = getUniqueDatesFromSource(source, dateKey);
+
+  const series = dates.map((date) => {
+    const results = getClosedPrPercentageByRepoUntilDate(source, date, {
+      scoreBounds,
+    });
+
+    const totalEligible = results.reduce(
+      (sum, result) => sum + result.elligiblePrs,
+      0,
+    );
+
+    const totalClosed = results.reduce(
+      (sum, result) => sum + result.closedPrs,
+      0,
+    );
+
+    return totalEligible > 0 ? (totalClosed / totalEligible) * 100 : null;
+  });
+
+  return {
+    name: "Automation PR closure rate",
+    series: series.map((value) => (value === null ? null : Math.round(value))),
+    type: "line",
+    smooth: true,
+  };
+}
+
+export function getClosedPrPercentageTotal(
+  source: EcosystemHealthItem[] = [],
+  scoreBounds: ScoreBounds = [0, 100],
+): number | null {
+  const [minScore, maxScore] = scoreBounds;
+
+  const eligiblePrs = source.filter((item) => {
+    const score = item.score ?? 0;
+    return score >= minScore && score <= maxScore;
+  });
+
+  if (eligiblePrs.length === 0) {
+    return null;
+  }
+
+  const closedPrs = eligiblePrs.filter(
+    (item) => item.pr_status === "closed",
+  ).length;
+
+  return Math.round((closedPrs / eligiblePrs.length) * 100);
+}

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -285,20 +285,9 @@ export function getClosedPrPercentageTotal(
   source: EcosystemHealthItem[] = [],
   scoreBounds: ScoreBounds = [0, 100],
 ): number | null {
-  const [minScore, maxScore] = scoreBounds;
-
-  const eligiblePrs = source.filter((item) => {
-    const score = item.score ?? 0;
-    return score >= minScore && score <= maxScore;
-  });
-
-  if (eligiblePrs.length === 0) {
-    return null;
-  }
-
-  const closedPrs = eligiblePrs.filter(
-    (item) => item.pr_status === "closed",
-  ).length;
-
-  return Math.round((closedPrs / eligiblePrs.length) * 100);
+  const results = getClosedPrPercentageByRepo(source, { scoreBounds });
+  const totalEligible = results.reduce((s, r) => s + r.elligiblePrs, 0);
+  const totalClosed = results.reduce((s, r) => s + r.closedPrs, 0);
+  if (totalEligible === 0) return null;
+  return Math.round((totalClosed / totalEligible) * 100);
 }


### PR DESCRIPTION
Resolves #154 

This adds to the health chart a dashed grey series to graph the PR closure rate from PRs evaluated as automation:

`automation PRs closed / total automation PRs`

You might need to rework the legend, which is kind of ugly now, I liked the 'trinity' we had before.
I would do it, but I'm really tired right now.

Yolo (in this branch but has nothing to do with the issue):
- add tooltips in the lab for sparklines to show the closed / total values on hover
- fix chart color reactivity to changes made to prefers-color-scheme on the fly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated PR closure-rate metric to the health page with label, percentage and color indicator.
  * Charts now include an overall PR-closure-percentage trend series and expose an average closure-rate value for UI use.
  * Chart tooltips append "%" only for the closure-rate series and charts use individual y-axis scaling.
  * Sparklines show a custom teleported tooltip with closed/eligible counts.

* **Improvements**
  * Theme/color handling made more robust for server-side rendering and prefers system dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->