### PR TITLE
fix: daily snapshot instead of cumulative

### DIFF
--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -102,7 +102,7 @@ function getLastPlotLabel(serie: Record<string, any>) {
 }
 
 type XyAugmentedSeries = VueUiXySeries[number] & {
-  details: { elligiblePrs: number[]; closedPrs: number[] };
+  details: { eligiblePrs: number[]; closedPrs: number[] };
 };
 
 function getTooltipContent(
@@ -111,18 +111,24 @@ function getTooltipContent(
 ) {
   const { absoluteIndex: index } = timeLabel;
   const datapoint = series[0] as unknown as XyAugmentedSeries;
-  const elligible = datapoint?.details?.elligiblePrs?.[index];
+  const eligible = datapoint?.details?.eligiblePrs?.[index];
   const closed = datapoint?.details?.closedPrs?.[index];
-  if (closed == null || elligible == null) return "";
-  return `${closed} / ${elligible}`;
+  if (closed == null || eligible == null) return "";
+  return `${closed} / ${eligible}`;
 }
 </script>
 
 <template>
-  <h2 class="text-center mb-3">
-    Evolution of pull request closure rates by repository for PRs in a given
-    score range.
-  </h2>
+  <div class="mb-5">
+    <h2 class="text-center">
+      Evolution of pull request closure rates by repository for PRs in a given
+      score range.
+    </h2>
+    <p class="text-sm text-gh-muted text-center">
+      Closure rates are based on daily snapshots, not cumulative history, so
+      counts may change from one day to the next.
+    </p>
+  </div>
 
   <div class="mb-4 flex items-center justify-center gap-6">
     <label class="font-medium">Score range</label>

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -181,7 +181,7 @@ export function getUniqueDatesFromSource(
   ).sort();
 }
 
-export function getClosedPrPercentageByRepoUntilDate(
+export function getClosedPrPercentageByRepoForDate(
   source: EcosystemHealthItem[],
   untilDate: string | Date,
   options: RepoClosedPrOptions = {},
@@ -242,7 +242,7 @@ export function getClosedPrPercentageEvolutionByRepo(
   >();
 
   dates.forEach((date, dateIndex) => {
-    const results = getClosedPrPercentageByRepoUntilDate(source, date, {
+    const results = getClosedPrPercentageByRepoForDate(source, date, {
       scoreBounds,
       dateKey,
     });
@@ -289,7 +289,7 @@ export function getClosedPrPercentageEvolutionTotal(
   const dates = getUniqueDatesFromSource(source, dateKey);
 
   const series = dates.map((date) => {
-    const results = getClosedPrPercentageByRepoUntilDate(source, date, {
+    const results = getClosedPrPercentageByRepoForDate(source, date, {
       scoreBounds,
     });
 
@@ -308,7 +308,7 @@ export function getClosedPrPercentageEvolutionTotal(
 
   return {
     name: "Automation PR closure rate",
-    series: series.map((value) => (value === null ? null : Math.round(value))),
+    series: series.map((value) => Math.round(value)),
     type: "line",
     smooth: true,
   };

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -291,6 +291,7 @@ export function getClosedPrPercentageEvolutionTotal(
   const series = dates.map((date) => {
     const results = getClosedPrPercentageByRepoForDate(source, date, {
       scoreBounds,
+      dateKey,
     });
 
     const totalEligible = results.reduce(

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -90,11 +90,9 @@ export function getClosedPrPercentageByRepo(
     prNumberKey = "pr_number",
     stateKey = "pr_status",
     scoreKey = "score",
-    dateKey = "created_at",
     scoreBounds = [0, 100],
     openState = "open",
     closedState = "closed",
-    includeAlreadyClosed = true,
   } = options;
 
   const resolvedScoreBounds: ScoreBounds = Array.isArray(scoreBounds)
@@ -110,70 +108,58 @@ export function getClosedPrPercentageByRepo(
     const prNumber = Number(entry[prNumberKey]);
 
     if (!repo || Number.isNaN(prNumber)) return;
-    if (!byRepo.has(repo)) byRepo.set(repo, new Map());
+
+    if (!byRepo.has(repo)) {
+      byRepo.set(repo, new Map());
+    }
 
     const repoMap = byRepo.get(repo);
     if (!repoMap) return;
-    if (!repoMap.has(prNumber)) repoMap.set(prNumber, []);
 
-    const pullRequestEntries = repoMap.get(prNumber);
-    if (!pullRequestEntries) return;
-    pullRequestEntries.push(entry);
+    if (!repoMap.has(prNumber)) {
+      repoMap.set(prNumber, []);
+    }
+
+    repoMap.get(prNumber)?.push(entry);
   });
 
   return Array.from(byRepo.entries()).map(([repo, pullRequests]) => {
-    let elligiblePrs = 0;
+    let eligiblePrs = 0;
     let closedPrs = 0;
 
     pullRequests.forEach((entries) => {
-      if (!entries.length) return;
+      const entriesInScoreRange = entries.filter((entry) => {
+        const score = Number(entry[scoreKey]);
+        const status = String(entry[stateKey]).toLowerCase();
 
-      const sortedEntries = [...entries].sort((a, b) => {
         return (
-          new Date(String(a[dateKey])).getTime() -
-          new Date(String(b[dateKey])).getTime()
+          !Number.isNaN(score) &&
+          score >= minScore &&
+          score <= maxScore &&
+          (status === openState || status === closedState)
         );
       });
 
-      const oldestEntry = sortedEntries[0];
-      if (!oldestEntry) return;
+      if (!entriesInScoreRange.length) return;
 
-      const latestEntry =
-        sortedEntries.length > 1
-          ? sortedEntries[sortedEntries.length - 1]
-          : undefined;
+      const hasClosedEntry = entriesInScoreRange.some((entry) => {
+        return String(entry[stateKey]).toLowerCase() === closedState;
+      });
 
-      const oldestStatus = String(oldestEntry[stateKey]).toLowerCase();
-      const oldestScore = Number(oldestEntry[scoreKey]);
-      const isAlreadyClosed = oldestStatus === closedState;
+      eligiblePrs += 1;
 
-      const isEligible =
-        oldestScore >= minScore &&
-        oldestScore <= maxScore &&
-        (oldestStatus === openState ||
-          (includeAlreadyClosed && isAlreadyClosed));
-
-      if (!isEligible) return;
-
-      elligiblePrs += 1;
-
-      if (isAlreadyClosed) {
+      if (hasClosedEntry) {
         closedPrs += 1;
-        return;
       }
-
-      if (!latestEntry) return;
-      const latestStatus = String(latestEntry[stateKey]).toLowerCase();
-      if (latestStatus === closedState) closedPrs += 1;
     });
 
     return {
       repo,
-      elligiblePrs,
+      eligiblePrs,
       closedPrs,
-      percentage: elligiblePrs
-        ? Number(((closedPrs / elligiblePrs) * 100).toFixed(2))
-        : 0,
+      percentage: eligiblePrs
+        ? Number(((closedPrs / eligiblePrs) * 100).toFixed(2))
+        : 100,
     };
   });
 }
@@ -203,7 +189,7 @@ export function getClosedPrPercentageByRepoUntilDate(
   const { dateKey = "created_at" } = options;
   const limitDay = getDayKey(untilDate);
   const filteredSource = source.filter((entry) => {
-    return getDayKey(String(entry[dateKey])) <= limitDay;
+    return getDayKey(String(entry[dateKey])) === limitDay; // <= limitDay to make it cumulative instead of daily
   });
   return getClosedPrPercentageByRepo(filteredSource, options);
 }
@@ -213,6 +199,32 @@ export type ClosedPrPercentageEvolutionSeries = {
   data: (number | null)[];
 };
 
+/**
+ * Sorry for the beefy comment but could not make the code clearer.
+ * ---
+ * Computes the daily snapshot closure-rate evolution for each repository.
+ *
+ * Each point represents the state of a repository on a specific day, not a
+ * cumulative history up to that day.
+ *
+ * For a given day:
+ * - Only entries where `dateKey` matches that given day are considered
+ * - PRs are deduped by `pr_number`
+ * - A PR is considered closed if at least one entry for that PR on that day has a closed status
+ * - A PR is considered eligible if it has at least one entry within the selected score range for that day
+ *
+ * Closure rate is calculated as:
+ *
+ *   closedPrs / eligiblePrs
+ *
+ * Because this is a daily snapshot:
+ * - The closedPrs numerator may vary from one day to another
+ * - The eligiblePrs denominator may also vary from one day to the next
+ * - If a PR is absent from a later snapshot, it no longer contributes to the
+ *   closure rate for that day, even if it was counted previously
+ *
+ * Empty snapshots (0 eligible PRs) are represented as 100%
+ */
 export function getClosedPrPercentageEvolutionByRepo(
   source: EcosystemHealthItem[] = [],
   scoreBounds: ScoreBounds = [0, 100],
@@ -224,7 +236,7 @@ export function getClosedPrPercentageEvolutionByRepo(
     string,
     {
       percentages: (number | null)[];
-      elligiblePrs: number[];
+      eligiblePrs: number[];
       closedPrs: number[];
     }
   >();
@@ -232,13 +244,14 @@ export function getClosedPrPercentageEvolutionByRepo(
   dates.forEach((date, dateIndex) => {
     const results = getClosedPrPercentageByRepoUntilDate(source, date, {
       scoreBounds,
+      dateKey,
     });
 
     results.forEach((result) => {
       if (!repoMap.has(result.repo)) {
         repoMap.set(result.repo, {
-          percentages: Array(dates.length).fill(null),
-          elligiblePrs: Array(dates.length).fill(0),
+          percentages: Array(dates.length).fill(100),
+          eligiblePrs: Array(dates.length).fill(0),
           closedPrs: Array(dates.length).fill(0),
         });
       }
@@ -247,10 +260,8 @@ export function getClosedPrPercentageEvolutionByRepo(
 
       if (!repoData) return;
 
-      repoData.percentages[dateIndex] =
-        result.elligiblePrs > 0 ? result.percentage : null;
-
-      repoData.elligiblePrs[dateIndex] = result.elligiblePrs;
+      repoData.percentages[dateIndex] = result.percentage;
+      repoData.eligiblePrs[dateIndex] = result.eligiblePrs;
       repoData.closedPrs[dateIndex] = result.closedPrs;
     });
   });
@@ -263,7 +274,7 @@ export function getClosedPrPercentageEvolutionByRepo(
       smooth: true,
       hasData: data.percentages.some((value) => value !== null),
       details: {
-        elligiblePrs: data.elligiblePrs,
+        eligiblePrs: data.eligiblePrs,
         closedPrs: data.closedPrs,
       },
     },
@@ -283,7 +294,7 @@ export function getClosedPrPercentageEvolutionTotal(
     });
 
     const totalEligible = results.reduce(
-      (sum, result) => sum + result.elligiblePrs,
+      (sum, result) => sum + result.eligiblePrs,
       0,
     );
 
@@ -292,7 +303,7 @@ export function getClosedPrPercentageEvolutionTotal(
       0,
     );
 
-    return totalEligible > 0 ? (totalClosed / totalEligible) * 100 : null;
+    return totalEligible > 0 ? (totalClosed / totalEligible) * 100 : 100;
   });
 
   return {
@@ -308,8 +319,8 @@ export function getClosedPrPercentageTotal(
   scoreBounds: ScoreBounds = [0, 100],
 ): number | null {
   const results = getClosedPrPercentageByRepo(source, { scoreBounds });
-  const totalEligible = results.reduce((s, r) => s + r.elligiblePrs, 0);
+  const totalEligible = results.reduce((s, r) => s + r.eligiblePrs, 0);
   const totalClosed = results.reduce((s, r) => s + r.closedPrs, 0);
-  if (totalEligible === 0) return null;
+  if (totalEligible === 0) return 100;
   return Math.round((totalClosed / totalEligible) * 100);
 }


### PR DESCRIPTION
This fixes the computation of the PR closure rate, to get daily snapshots instead of cumulative ratios.

Now we have: `How many PR are closed today / how many PR exist today`

instead of : `How many Prs have ever become closed up to this day / how many Prs have appeared up to this day`

Charts affected:
- health chart
- lab sparklines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PR closure percentage calculations and eligibility tracking across repositories.
  * Fixed tooltip content so daily snapshot tooltips show correct "closed / eligible" values and hide when data is missing.
  * Improved default percentage handling to show 100% when no eligible PRs exist.
  * Adjusted chart header layout and added a descriptive paragraph about daily snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->