### PR TITLE
feat: add trends in health chart

### DIFF
--- a/app/components/Chart/FeaturedPackageHealthRanking.vue
+++ b/app/components/Chart/FeaturedPackageHealthRanking.vue
@@ -4,8 +4,8 @@ import {
   type VueUiHorizontalBarDatasetItem,
   type VueUiHorizontalBarConfig,
 } from "vue-data-ui/vue-ui-horizontal-bar";
-import "vue-data-ui/style.css";
 import { interpolateHexColors } from "~/utils/colors";
+import("vue-data-ui/style.css");
 
 const { data } = useEcosystemHealth();
 

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -87,17 +87,12 @@ const dataset = computed<VueUiXyDatasetItem[]>(() => [
   automatedClosureRateData.value,
 ]);
 
-const timestamps = computed(() => {
-  if (!data.value?.length) return [];
-  return [...new Set(data.value.map((item) => item.created_at))].sort();
-});
-
 const tooltipPosition = useChartTooltipPosition(chartRef);
 
 const progressionLabelOffsetX = 6; // compensate hard-coded internal in VueUiXy
 
 const viewBoxPadding = computed(() => {
-  const maxSeries = timestamps.value.length;
+  const maxSeries = dates.value.length;
   if (maxSeries <= 1) return { left: 0, right: 0 };
   const halfVueUiXyDatapointStep = width.value / (2 * (maxSeries - 1));
   return {
@@ -135,7 +130,7 @@ const config = computed<VueUiXyConfig>(() => ({
         },
         xAxisLabels: {
           show: false,
-          values: timestamps.value,
+          values: dates.value,
           datetimeFormatter: {
             enable: true,
             useUTC: true,

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -12,6 +12,7 @@ import { getClosedPrPercentageEvolutionTotal } from "~/utils/charts";
 import("vue-data-ui/style.css");
 
 const { data } = await useEcosystemHealth();
+const { dates, countsByDate } = useEcosystemHealthCountsByDate();
 
 const chartContainer = useTemplateRef<HTMLElement>("chartContainer");
 const { width, height } = useElementSize(chartContainer);
@@ -34,41 +35,10 @@ const automatedClosureRateData = computed(() => ({
 }));
 
 function composeRawDataset(): VueUiXyDatasetItem[] {
-  const sumsByDate: Record<
-    string,
-    {
-      automation: number;
-      mixed: number;
-      organic: number;
-    }
-  > = {};
-
-  const categories = [...new Set(data.value.map((d) => d.created_at))].sort();
-
-  categories.forEach((date) => {
-    sumsByDate[date] = {
-      automation: 0,
-      mixed: 0,
-      organic: 0,
-    };
-  });
-
-  data.value.forEach((d) => {
-    const dateSums = sumsByDate[d.created_at];
-    if (!dateSums) return;
-    if (d.score <= 50) {
-      dateSums.automation += 1;
-    } else if (d.score <= 70) {
-      dateSums.mixed += 1;
-    } else {
-      dateSums.organic += 1;
-    }
-  });
-
   return [
     {
       name: "Organic",
-      series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
+      series: dates.value.map((date) => countsByDate.value[date]?.organic ?? 0),
       color: colors.value.greenLine,
       type: "line",
       smooth: true,
@@ -76,7 +46,7 @@ function composeRawDataset(): VueUiXyDatasetItem[] {
     },
     {
       name: "Mixed",
-      series: categories.map((date) => sumsByDate[date]?.mixed ?? 0),
+      series: dates.value.map((date) => countsByDate.value[date]?.mixed ?? 0),
       color: colors.value.amber,
       type: "line",
       smooth: true,
@@ -84,7 +54,9 @@ function composeRawDataset(): VueUiXyDatasetItem[] {
     },
     {
       name: "Automation",
-      series: categories.map((date) => sumsByDate[date]?.automation ?? 0),
+      series: dates.value.map(
+        (date) => countsByDate.value[date]?.automation ?? 0,
+      ),
       color: colors.value.dangerHover,
       type: "line",
       smooth: true,

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -8,6 +8,7 @@ import {
 import { useChartTooltipPosition } from "~/composables/useChartTooltipPosition";
 import { useColors } from "~/composables/useColors";
 import { getClosedPrPercentageEvolutionTotal } from "~/utils/charts";
+import { identityConfig } from "@unveil/identity";
 
 import("vue-data-ui/style.css");
 
@@ -27,7 +28,10 @@ onMounted(async () => {
 const colors = useColors(rootEl);
 
 const automatedClosureRateData = computed(() => ({
-  ...getClosedPrPercentageEvolutionTotal(data.value, [0, 50]),
+  ...getClosedPrPercentageEvolutionTotal(data.value, [
+    0,
+    identityConfig.THRESHOLD_SUSPICIOUS,
+  ]),
   scaleMin: 0,
   scaleMax: 100,
   color: "grey",

--- a/app/components/Chart/GlobalEventsHeatmap.vue
+++ b/app/components/Chart/GlobalEventsHeatmap.vue
@@ -9,6 +9,7 @@ import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
 import dayjs from "dayjs";
 import isoWeek from "dayjs/plugin/isoWeek";
 import { mergeConfigs } from "vue-data-ui/utils";
+import("vue-data-ui/style.css");
 
 dayjs.extend(isoWeek);
 

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -6,20 +6,28 @@ import {
   type VueUiXySeries,
   type VueUiXyTooltipSlotProps,
 } from "vue-data-ui/vue-ui-xy";
-import "vue-data-ui/style.css";
+import { identityConfig } from "@unveil/identity";
+
+import("vue-data-ui/style.css");
 
 const { data } = useEcosystemHealth();
 const rootEl = shallowRef<HTMLElement | null>(null);
 const colors = useColors(rootEl);
 
-const scoreBounds = shallowRef<ScoreBounds>([0, 50]);
+const scoreBounds = shallowRef<ScoreBounds>([
+  0,
+  identityConfig.THRESHOLD_SUSPICIOUS,
+]);
 
 const selectedRangeColor = computed(() => {
   const [minScore, maxScore] = scoreBounds.value;
-  if (minScore === 0 && maxScore === 50) {
+  if (minScore === 0 && maxScore === identityConfig.THRESHOLD_SUSPICIOUS) {
     return colors.value.danger;
   }
-  if (minScore === 50 && maxScore === 70) {
+  if (
+    minScore === identityConfig.THRESHOLD_SUSPICIOUS &&
+    maxScore === identityConfig.THRESHOLD_HUMAN
+  ) {
     return colors.value.amber;
   }
   return colors.value.green;
@@ -137,30 +145,37 @@ function getTooltipContent(
       <input
         v-model="scoreBounds"
         type="radio"
-        :value="[0, 50]"
+        :value="[0, identityConfig.THRESHOLD_SUSPICIOUS]"
         class="accent-red"
       />
-      <span>0-50</span>
+      <span>0-{{ identityConfig.THRESHOLD_SUSPICIOUS }}</span>
     </label>
 
     <label class="flex items-center gap-2 cursor-pointer">
       <input
         v-model="scoreBounds"
         type="radio"
-        :value="[50, 70]"
+        :value="[
+          identityConfig.THRESHOLD_SUSPICIOUS,
+          identityConfig.THRESHOLD_HUMAN,
+        ]"
         class="accent-amber"
       />
-      <span>50-70</span>
+      <span
+        >{{ identityConfig.THRESHOLD_SUSPICIOUS }}-{{
+          identityConfig.THRESHOLD_HUMAN
+        }}</span
+      >
     </label>
 
     <label class="flex items-center gap-2 cursor-pointer">
       <input
         v-model="scoreBounds"
         type="radio"
-        :value="[70, 100]"
+        :value="[identityConfig.THRESHOLD_HUMAN, 100]"
         class="accent-green"
       />
-      <span>70-100</span>
+      <span>{{ identityConfig.THRESHOLD_HUMAN }}-100</span>
     </label>
   </div>
 

--- a/app/composables/useEcosystemHealthCategoryProgression.ts
+++ b/app/composables/useEcosystemHealthCategoryProgression.ts
@@ -1,0 +1,26 @@
+import { calcLinearProgression } from "#imports";
+
+export function useEcosystemHealthCategoryProgression() {
+  const { dates, countsByDate } = useEcosystemHealthCountsByDate();
+
+  const progression = computed(() => {
+    const automation: number[] = [];
+    const mixed: number[] = [];
+    const organic: number[] = [];
+
+    dates.value.forEach((date) => {
+      const counts = countsByDate.value[date];
+      automation.push(counts?.automation ?? 0);
+      mixed.push(counts?.mixed ?? 0);
+      organic.push(counts?.organic ?? 0);
+    });
+
+    return {
+      automation: calcLinearProgression(automation),
+      mixed: calcLinearProgression(mixed),
+      organic: calcLinearProgression(organic),
+    };
+  });
+
+  return { progression };
+}

--- a/app/composables/useEcosystemHealthCountsByDate.ts
+++ b/app/composables/useEcosystemHealthCountsByDate.ts
@@ -1,0 +1,50 @@
+type EcosystemHealthCategoryCounts = {
+  automation: number;
+  mixed: number;
+  organic: number;
+};
+
+export function useEcosystemHealthCountsByDate() {
+  const { data } = useEcosystemHealth();
+
+  const countsByDate = computed<Record<string, EcosystemHealthCategoryCounts>>(
+    () => {
+      const result: Record<string, EcosystemHealthCategoryCounts> = {};
+
+      const dates = [
+        ...new Set(data.value.map((item) => item.created_at)),
+      ].sort();
+
+      dates.forEach((date) => {
+        result[date] = {
+          automation: 0,
+          mixed: 0,
+          organic: 0,
+        };
+      });
+
+      data.value.forEach((item) => {
+        const dateCounts = result[item.created_at];
+
+        if (!dateCounts) return;
+
+        if (item.score <= 50) {
+          dateCounts.automation += 1;
+        } else if (item.score <= 70) {
+          dateCounts.mixed += 1;
+        } else {
+          dateCounts.organic += 1;
+        }
+      });
+
+      return result;
+    },
+  );
+
+  const dates = computed(() => Object.keys(countsByDate.value).sort());
+
+  return {
+    dates,
+    countsByDate,
+  };
+}

--- a/app/composables/useEcosystemHealthCountsByDate.ts
+++ b/app/composables/useEcosystemHealthCountsByDate.ts
@@ -1,3 +1,5 @@
+import { identityConfig } from "@unveil/identity";
+
 type EcosystemHealthCategoryCounts = {
   automation: number;
   mixed: number;
@@ -28,9 +30,9 @@ export function useEcosystemHealthCountsByDate() {
 
         if (!dateCounts) return;
 
-        if (item.score <= 50) {
+        if (item.score <= identityConfig.THRESHOLD_SUSPICIOUS) {
           dateCounts.automation += 1;
-        } else if (item.score <= 70) {
+        } else if (item.score <= identityConfig.THRESHOLD_HUMAN) {
           dateCounts.mixed += 1;
         } else {
           dateCounts.organic += 1;

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -119,9 +119,9 @@ function formatTrend(value: number) {
 }
 
 function getTrendArrow(value: number) {
-  if (value > 0) return "i-carbon-arrow-up-right";
-  if (value < 0) return "i-carbon-arrow-down-right";
-  return "i-carbon-arrow-right";
+  if (value > 0) return "i-lucide:trending-up";
+  if (value < 0) return "i-lucide:trending-down";
+  return "i-lucide:trending-up-down";
 }
 
 function getTrendColor({

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -78,15 +78,15 @@ const latestDayStats = computed<ClassificationStats | null>(() => {
   return {
     organic: {
       count: counts.organic,
-      percentage: formatPercentage((counts.organic / totalCount) * 100) ?? 0,
+      percentage: formatPercentage((counts.organic / totalCount) * 100),
     },
     mixed: {
       count: counts.mixed,
-      percentage: formatPercentage((counts.mixed / totalCount) * 100) ?? 0,
+      percentage: formatPercentage((counts.mixed / totalCount) * 100),
     },
     automation: {
       count: counts.automation,
-      percentage: formatPercentage((counts.automation / totalCount) * 100) ?? 0,
+      percentage: formatPercentage((counts.automation / totalCount) * 100),
     },
   };
 });

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -123,6 +123,18 @@ function getTrendArrow(value: number) {
   if (value < 0) return "i-carbon-arrow-down-right";
   return "i-carbon-arrow-right";
 }
+
+function getTrendColor({
+  value,
+  reversed = false,
+}: {
+  value: number;
+  reversed?: boolean;
+}) {
+  if (value > 0) return reversed ? "text-gh-red" : "text-gh-green";
+  if (value < 0) return reversed ? "text-gh-green" : "text-gh-red";
+  return "text-gh-muted";
+}
 </script>
 
 <template>
@@ -167,17 +179,20 @@ function getTrendArrow(value: number) {
                 {{ config.label }}
 
                 <span class="text-gh-muted ml-1">
-                  ({{
-                    Math.round(
-                      Number(latestDayStats?.[config.key]?.percentage ?? 0),
-                    )
-                  }}%)
+                  {{ latestDayStats?.[config.key]?.percentage }}%
                 </span>
 
-                <span class="text-gh-muted">
+                <span
+                  :class="[
+                    getTrendColor({
+                      value: progression[config.key].trend,
+                      reversed: config.key !== 'organic',
+                    }),
+                  ]"
+                >
                   <span
-                    :class="getTrendArrow(progression[config.key].trend)"
-                    class="text-gh-text shrink-0"
+                    :class="[getTrendArrow(progression[config.key].trend)]"
+                    class="shrink-0"
                     style="vertical-align: middle"
                   />
                   {{ formatTrend(progression[config.key].trend) }}

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -78,15 +78,15 @@ const latestDayStats = computed<ClassificationStats | null>(() => {
   return {
     organic: {
       count: counts.organic,
-      percentage: formatPercentage((counts.organic / totalCount) * 100),
+      percentage: formatPercentage((counts.organic / totalCount) * 100) ?? 0,
     },
     mixed: {
       count: counts.mixed,
-      percentage: formatPercentage((counts.mixed / totalCount) * 100),
+      percentage: formatPercentage((counts.mixed / totalCount) * 100) ?? 0,
     },
     automation: {
       count: counts.automation,
-      percentage: formatPercentage((counts.automation / totalCount) * 100),
+      percentage: formatPercentage((counts.automation / totalCount) * 100) ?? 0,
     },
   };
 });
@@ -110,6 +110,19 @@ const hasEnoughData = computed(() => {
 
   return uniqueDates.size >= MIN_DAY_DATA_COLLECTION;
 });
+
+const { progression } = useEcosystemHealthCategoryProgression();
+
+function formatTrend(value: number) {
+  if (value > 0) return `+${(value * 100).toFixed(0)}%`;
+  return `${(value * 100).toFixed(0)}%`;
+}
+
+function getTrendArrow(value: number) {
+  if (value > 0) return "i-carbon-arrow-up-right";
+  if (value < 0) return "i-carbon-arrow-down-right";
+  return "i-carbon-arrow-right";
+}
 </script>
 
 <template>
@@ -149,12 +162,25 @@ const hasEnoughData = computed(() => {
               <span
                 :class="`size-2 ${config.bgColor} block rounded-full`"
               ></span>
+
               <p class="text-sm">
                 {{ config.label }}
+
+                <span class="text-gh-muted ml-1">
+                  ({{
+                    Math.round(
+                      Number(latestDayStats?.[config.key]?.percentage ?? 0),
+                    )
+                  }}%)
+                </span>
+
                 <span class="text-gh-muted">
-                  {{ latestDayStats?.[config.key].percentage }}% ({{
-                    latestDayStats?.[config.key].count
-                  }})
+                  <span
+                    :class="getTrendArrow(progression[config.key].trend)"
+                    class="text-gh-text shrink-0"
+                    style="vertical-align: middle"
+                  />
+                  {{ formatTrend(progression[config.key].trend) }}
                 </span>
               </p>
             </li>

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -1,109 +1,47 @@
 <script setup lang="ts">
 import type { VueUiStacklineDatasetItem } from "vue-data-ui/vue-ui-stackline";
 
-// NOTE: The data treatment is identical to the one on /health
-// Eventually, we can just move the heatmaps there ?
-// If not, we'll make a composable to centralize data computation
-const { data } = useEcosystemHealth();
-
 definePageMeta({
   layout: false,
 });
 
 const rootEl = shallowRef<HTMLElement | null>(null);
 const colors = useColors(rootEl);
+const { dates, countsByDate } = useEcosystemHealthCountsByDate();
 
-function createChartDataset(source?: EcosystemHealthItem[]): {
+function createChartDataset(): {
   categories: string[];
   dataset: VueUiStacklineDatasetItem[];
 } {
-  if (!source?.length) {
-    return {
-      categories: [],
-      dataset: [
-        {
-          name: "Organic",
-          series: [],
-          color: colors.value.greenLine,
-        },
-        {
-          name: "Mixed",
-          series: [],
-          color: colors.value.amber,
-        },
-        {
-          name: "Automation",
-          series: [],
-          color: colors.value.dangerHover,
-        },
-      ],
-    };
-  }
-
-  const categories = [...new Set(source.map((item) => item.created_at))].sort();
-
-  const sumsByDate: Record<
-    string,
-    {
-      automation: number;
-      mixed: number;
-      organic: number;
-    }
-  > = {};
-
-  categories.forEach((date) => {
-    sumsByDate[date] = {
-      automation: 0,
-      mixed: 0,
-      organic: 0,
-    };
-  });
-
-  source.forEach((item) => {
-    const dateSums = sumsByDate[item.created_at];
-
-    if (!dateSums) return;
-
-    if (item.score <= 50) {
-      dateSums.automation += 1;
-    } else if (item.score <= 70) {
-      dateSums.mixed += 1;
-    } else {
-      dateSums.organic += 1;
-    }
-  });
-
   return {
-    categories,
+    categories: dates.value,
     dataset: [
       {
         name: "Organic",
-        series: categories.map((date) => sumsByDate[date]?.organic ?? 0),
+        series: dates.value.map(
+          (date) => countsByDate.value[date]?.organic ?? 0,
+        ),
         color: colors.value.greenLine,
       },
       {
         name: "Mixed",
-        series: categories.map((date) => sumsByDate[date]?.mixed ?? 0),
+        series: dates.value.map((date) => countsByDate.value[date]?.mixed ?? 0),
         color: colors.value.amber,
       },
       {
         name: "Automation",
-        series: categories.map((date) => sumsByDate[date]?.automation ?? 0),
+        series: dates.value.map(
+          (date) => countsByDate.value[date]?.automation ?? 0,
+        ),
         color: colors.value.dangerHover,
       },
     ],
   };
 }
 
-const stacklineData = computed(() => createChartDataset(data.value));
+const stacklineData = computed(() => createChartDataset());
 
 const dataset = computed(() => stacklineData.value.dataset);
-
-const timestamps = computed(() => {
-  if (!data.value?.length) return [];
-
-  return [...new Set(data.value.map((item) => item.created_at))].sort();
-});
 </script>
 
 <template>
@@ -145,7 +83,7 @@ const timestamps = computed(() => {
           <ChartFeaturedPackageHealthRanking />
         </div>
         <div class="w-full">
-          <ChartGlobalEventsHeatmap :data="dataset" :timestamps />
+          <ChartGlobalEventsHeatmap :data="dataset" :timestamps="dates" />
         </div>
         <div class="w-full">
           <h2 class="text-xl font-semibold mb-4">Scan Results by User ID</h2>

--- a/app/utils/charts.ts
+++ b/app/utils/charts.ts
@@ -325,3 +325,58 @@ export function getClosedPrPercentageTotal(
   if (totalEligible === 0) return 100;
   return Math.round((totalClosed / totalEligible) * 100);
 }
+
+export function calcLinearProgression(values: number[]) {
+  const len = values?.length ?? 0;
+
+  if (len < 2) {
+    return {
+      x1: 0,
+      y1: 0,
+      x2: 0,
+      y2: 0,
+      slope: 0,
+      trend: 0,
+    };
+  }
+
+  let sx = 0;
+  let sy = 0;
+  let sxy = 0;
+  let sxx = 0;
+
+  for (let i = 0; i < len; i += 1) {
+    const x = i;
+    const y = values[i] ?? 0;
+
+    sx += x;
+    sy += y;
+    sxy += x * y;
+    sxx += x * x;
+  }
+
+  const denominator = len * sxx - sx * sx || 1;
+  const slope = (len * sxy - sx * sy) / denominator;
+  const intercept = (sy - slope * sx) / len;
+
+  const x1 = 0;
+  const x2 = len - 1;
+  const y1 = intercept;
+  const y2 = slope * x2 + intercept;
+
+  const average = sy / len;
+
+  const EPS = 1e-9;
+  const scale = Math.max(Math.abs(y1), Math.abs(average), Math.abs(y2), EPS);
+
+  const trend = (y2 - y1) / scale;
+
+  return {
+    x1,
+    y1,
+    x2,
+    y2,
+    slope,
+    trend,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.21.0",
+        "vue-data-ui": "^3.21.1",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -2141,9 +2141,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2159,9 +2156,6 @@
       "integrity": "sha512-HGzqTov5sAzXyaNfRkQEpl0fRs+PrMYjT8b5jZAw8foQ/qnW+VMWgAr80Q+2j79T5nhXfboSF5SUgB8mcisgHw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2179,9 +2173,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2197,9 +2188,6 @@
       "integrity": "sha512-CYrC4tpW1wolbw/Fox+T0hxW92s1aG/WLi+htkk02JMiCHOWqGQKxUnm37lLiODKR/OwTYht3LB4xNrsS0RtCg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2217,9 +2205,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2235,9 +2220,6 @@
       "integrity": "sha512-tR8oiFSNpcS1mfGY1N3/Hy6TxP2wr5X9FFdn/y8GarN8ST/JMLY5SUiwPiU35NKiC69CDaAsLHXoIKUxK/r8Pw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2255,9 +2237,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2273,9 +2252,6 @@
       "integrity": "sha512-CNG3/hPE6MxdLikfLq5l0aZMvJ3W5AP1aoVjzQ1Itokv5sbfBcW0fp6Srn8mB86CyAqO9e7dbffZVOWBDVkhgw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2375,6 +2351,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2392,6 +2369,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,6 +2387,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2426,6 +2405,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2443,6 +2423,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2460,6 +2441,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2477,6 +2459,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2494,9 +2477,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2514,9 +2495,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2534,9 +2513,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2554,9 +2531,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2574,9 +2549,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2594,9 +2567,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2614,9 +2585,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2634,9 +2603,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2654,6 +2621,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2671,6 +2639,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2690,6 +2659,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2707,6 +2677,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2724,6 +2695,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2864,9 +2836,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2882,9 +2851,6 @@
       "integrity": "sha512-cW0Ab1s0sxfiyP1+gdd94f0vUjwGzJF4F3DepF3VnR9nFTGMmFLugwtrBS3DYjTnbugiUH3Fp+16yys1FhNzIA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2902,9 +2868,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2920,9 +2883,6 @@
       "integrity": "sha512-r4sMt4OB4TryDcVWW9KnsXOf/ea7tIGX2QASNrpetzPocsBZqhHIFDbZ8EkBDjmlmWGHg6BgjVx6lLcMXX4Dcw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2940,9 +2900,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2958,9 +2915,6 @@
       "integrity": "sha512-fUprJgJauI1A7e7cDgY/Z3mwLVtE3aswB4lvS96KpRNDHrwOh8bnCJOWf+0CYveDQzghDVFiZWVDo56pO4Wr9Q==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2978,9 +2932,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2996,9 +2947,6 @@
       "integrity": "sha512-Du2CxlBfC98EV3hOAmLVSUgP0JgqM9F47lRv9v43T4sGPcQVOjs9wffUybGUUraG9unmBZ4dgpMAqlCq0k3dGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3213,9 +3161,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3235,9 +3180,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3259,9 +3201,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3281,9 +3220,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3305,9 +3241,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3327,9 +3260,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3767,9 +3697,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3782,9 +3709,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3799,9 +3723,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3814,9 +3735,6 @@
       "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3831,9 +3749,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3846,9 +3761,6 @@
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3863,9 +3775,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3878,9 +3787,6 @@
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3895,9 +3801,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3910,9 +3813,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3927,9 +3827,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3943,9 +3840,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3958,9 +3852,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4497,9 +4388,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4517,9 +4405,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4537,9 +4422,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4557,9 +4439,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4577,9 +4456,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4597,9 +4473,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4617,9 +4490,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4637,9 +4507,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4744,6 +4611,30 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@unocss/nuxt/node_modules/@unocss/astro": {
+      "version": "66.6.7",
+      "resolved": "https://registry.npmjs.org/@unocss/astro/-/astro-66.6.7.tgz",
+      "integrity": "sha512-Vk/4sZWGgusROqL4eMgp3uZVYDDdfknNPyn1ij1dNPw2HV/m79U4QKpjpZvnr9XwrX9i4CMgc1TcZdC9T4gzuA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@unocss/core": "66.6.7",
+        "@unocss/reset": "66.6.7",
+        "@unocss/vite": "66.6.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@unocss/nuxt/node_modules/@unocss/cli": {
       "version": "66.6.7",
       "resolved": "https://registry.npmjs.org/@unocss/cli/-/cli-66.6.7.tgz",
@@ -4834,6 +4725,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@unocss/nuxt/node_modules/@unocss/postcss": {
+      "version": "66.6.7",
+      "resolved": "https://registry.npmjs.org/@unocss/postcss/-/postcss-66.6.7.tgz",
+      "integrity": "sha512-ArXEkhP2czxkeKQKI7RqmZiw3n8Kj6AR+WIssta/KgLRefEbYHJht3a2qgP739a1uSDYnvn19SN40+i7TCpKrg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@unocss/config": "66.6.7",
+        "@unocss/core": "66.6.7",
+        "@unocss/rule-utils": "66.6.7",
+        "css-tree": "^3.1.0",
+        "postcss": "^8.5.6",
+        "tinyglobby": "^0.2.15"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/@unocss/nuxt/node_modules/@unocss/preset-attributify": {
@@ -10604,9 +10520,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10622,9 +10535,6 @@
       "integrity": "sha512-vtPiwmfVTAXzaxDKsOXG+LwgRAA7WEnaeHzhS5z0GE89gAK18KSXnly7Z6saXXq6L3dVMyK44uoTI03zKxrpmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -10642,9 +10552,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10660,9 +10567,6 @@
       "integrity": "sha512-vvpjkjEOUsPcsYf8evE4MO3aGx9+3wodXEBOicGNnOwTuAik8eBONNkgSdhkGsAblQmfVHJyanRnpxglddTXIA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -10680,9 +10584,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10698,9 +10599,6 @@
       "integrity": "sha512-7d3jOMKy7RSQCcDLIci+ySll2FgsOMl/GiRux4q2JNv0zg4EdhFISa9idvrdN/HEUIQQJNg6dmveUeJl2YErGA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -10718,9 +10616,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10736,9 +10631,6 @@
       "integrity": "sha512-b2BO82O8azXAyf7EUgOPKu145nWypbNyk07HbU09fkzhm9lEA5oPvaN/M8Nlo7tOErVTa2WOgS4QbOnxAPXdDQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -14032,10 +13924,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.0.tgz",
-      "integrity": "sha512-jfZhLeHa1c7t3wUbUBuz/HrgpxuvL4MC9DPPV9LlIl+qDEG/weGjXK9HBVGkkkhkArmlSa7yN2j6T+ghNSgc1Q==",
-      "license": "MIT",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.1.tgz",
+      "integrity": "sha512-iInl5SNpQXuCF5pGrzJkdr83kfYevUP3slu9d4QMSK1qNc8WejLYeC/HHDDobei7hJvUqy8zSuZt/4vs7lhxWw==",
       "peerDependencies": {
         "jspdf": ">=3.0.1",
         "vue": ">=3.3.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.21.0",
+    "vue-data-ui": "^3.21.1",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This adds trend percentages for each category of the trends chart, shown in the legend items.
I also refactored composables, since both the chart and the trend share common logic; and use the constants from @unveil/identity.
Also updated vue-data-ui to latest, just to keep fresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trend indicators with numeric trend data for each health category.
  * Date-based charts showing per-category time series (Organic, Mixed, Automation).
  * New progression/trend calculation powering category trends.

* **Improvements**
  * Score-range controls and sparklines now respect configurable thresholds and updated range labels.
  * Chart aggregation consolidated to produce more accurate counts by date.
  * Page layout adjusted for centered content.

* **Chores**
  * Dependency bumped to 3.21.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->