### PR TITLE
feat(analysis-card): add nearest classification

### DIFF
--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -126,28 +126,8 @@ const identifyAnalysis = computed<IdentifyReplicantResult | undefined>(() => {
   return data.value?.analysis;
 });
 
-const CLASSIFICATION_PROXIMITY_THRESHOLD = 15;
-const nearestClassification = computed<IdentityClassification | undefined>(
-  () => {
-    if (!data.value) {
-      return;
-    }
-
-    const { score } = data.value.analysis;
-
-    if (score >= 70 && score - 70 <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
-      return "mixed";
-    } else if (
-      score >= 50 &&
-      score - 50 <= CLASSIFICATION_PROXIMITY_THRESHOLD
-    ) {
-      return "automation";
-    } else if (score < 50 && 50 - score <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
-      return "mixed";
-    } else if (score < 70 && 70 - score <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
-      return "organic";
-    }
-  },
+const { nearestClassification } = useNearestClassification(
+  data.value?.analysis.score,
 );
 
 useSeoAnalysis(identifyAnalysis, {

--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { identityConfig } from "@unveil/identity";
 import dayjs from "dayjs";
 
 const props = defineProps<{
@@ -125,6 +126,30 @@ const identifyAnalysis = computed<IdentifyReplicantResult | undefined>(() => {
   return data.value?.analysis;
 });
 
+const CLASSIFICATION_PROXIMITY_THRESHOLD = 15;
+const nearestClassification = computed<IdentityClassification | undefined>(
+  () => {
+    if (!data.value) {
+      return;
+    }
+
+    const { score } = data.value.analysis;
+
+    if (score >= 70 && score - 70 <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+      return "mixed";
+    } else if (
+      score >= 50 &&
+      score - 50 <= CLASSIFICATION_PROXIMITY_THRESHOLD
+    ) {
+      return "automation";
+    } else if (score < 50 && 50 - score <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+      return "mixed";
+    } else if (score < 70 && 70 - score <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+      return "organic";
+    }
+  },
+);
+
 useSeoAnalysis(identifyAnalysis, {
   hasCommunityFlag,
   hasActivityReport,
@@ -141,13 +166,25 @@ useSeoAnalysis(identifyAnalysis, {
     >
       <div class="w-full">
         <header class="flex items-center justify-between mb-2">
-          <div>
-            <span class="flex gap-2 items-center mb-2" :class="scoreStyle.text">
-              <span :class="classificationIcon" class="text-base" />
-              <h3 class="text-xl font-mono">
-                {{ classificationDetails.label }}
-              </h3>
-            </span>
+          <div class="w-full">
+            <div class="mb-2 flex flex-col">
+              <div
+                v-if="nearestClassification"
+                class="flex items-center gap-2 text-sm text-gh-muted mb-2"
+              >
+                <span class="i-lucide:trending-up-down text-xs"></span>
+                <span class="text-pretty line-height-none">
+                  trending toward
+                  {{ nearestClassification }} activity.
+                </span>
+              </div>
+              <span class="flex gap-2 items-center" :class="scoreStyle.text">
+                <span :class="classificationIcon" class="text-base" />
+                <h3 class="text-xl font-mono">
+                  {{ classificationDetails.label }}
+                </h3>
+              </span>
+            </div>
             <p class="mt-1 text-gh-text">
               {{ classificationDetails.description }}
             </p>

--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -126,9 +126,11 @@ const identifyAnalysis = computed<IdentifyReplicantResult | undefined>(() => {
   return data.value?.analysis;
 });
 
-const { nearestClassification } = useNearestClassification(
-  data.value?.analysis.score,
-);
+const score = computed<number | undefined>(() => {
+  return data.value?.analysis.score;
+});
+
+const { nearestClassification } = useNearestClassification(score);
 
 useSeoAnalysis(identifyAnalysis, {
   hasCommunityFlag,

--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -154,10 +154,9 @@ useSeoAnalysis(identifyAnalysis, {
                 v-if="nearestClassification"
                 class="flex items-center gap-2 text-sm text-gh-muted mb-2"
               >
-                <span class="i-lucide:trending-up-down text-xs"></span>
+                <span class="i-lucide:megaphone text-xs"></span>
                 <span class="text-pretty line-height-none">
-                  trending toward
-                  {{ nearestClassification }} activity.
+                  Activity close to {{ nearestClassification }} signals.
                 </span>
               </div>
               <span class="flex gap-2 items-center" :class="scoreStyle.text">

--- a/app/components/Analysis/ScanListTable.vue
+++ b/app/components/Analysis/ScanListTable.vue
@@ -9,8 +9,10 @@ interface RepoStats {
 
 interface UserStat {
   user_id: number;
+  username: string;
   repos: RepoStats[];
   total_open_prs: number;
+  score: number;
   total_prs: number;
   days_seen: string[];
 }
@@ -30,6 +32,8 @@ const userStats = computed<Record<number, UserStat>>(() => {
     if (!stats[entry.user_id]) {
       stats[entry.user_id] = {
         user_id: entry.user_id,
+        username: entry.username,
+        score: entry.score,
         repos: [],
         total_open_prs: 0,
         total_prs: 0,
@@ -163,7 +167,8 @@ function formatDate(dateStr: string): string {
       <table class="w-full">
         <thead class="bg-gh-card border-b border-gh-border">
           <tr>
-            <th class="px-4 py-3 text-left text-sm font-semibold">User ID</th>
+            <th class="px-4 py-3 text-left text-sm font-semibold">Username</th>
+            <th class="px-4 py-3 text-left text-sm font-semibold">Score</th>
             <th class="px-4 py-3 text-left text-sm font-semibold">
               Repositories
             </th>
@@ -185,7 +190,10 @@ function formatDate(dateStr: string): string {
             class="border-b border-gh-border hover:bg-gh-card transition-colors"
           >
             <td class="px-4 py-3 font-mono text-sm text-gh-muted">
-              {{ user.user_id }}
+              {{ user.username }}
+            </td>
+            <td class="px-4 py-3 font-mono text-sm text-gh-muted">
+              {{ user.score }}
             </td>
             <td class="px-4 py-3 text-sm">
               {{ user.repos.length }}

--- a/app/composables/useNearestClassification.ts
+++ b/app/composables/useNearestClassification.ts
@@ -1,0 +1,49 @@
+import { identityConfig } from "@unveil/identity";
+
+export type UseNearestClassificationReturn = {
+  nearestClassification: ComputedRef<IdentityClassification | undefined>;
+};
+
+const CLASSIFICATION_PROXIMITY_THRESHOLD = 15;
+
+export function useNearestClassification(
+  score: MaybeRefOrGetter<number | undefined>,
+): UseNearestClassificationReturn {
+  const nearestClassification = computed<IdentityClassification | undefined>(
+    () => {
+      const scoreValue = toValue(score);
+
+      if (scoreValue === undefined) {
+        return;
+      }
+
+      if (scoreValue >= identityConfig.THRESHOLD_HUMAN) {
+        const dist = scoreValue - identityConfig.THRESHOLD_HUMAN;
+        return dist <= CLASSIFICATION_PROXIMITY_THRESHOLD ? "mixed" : undefined;
+      }
+
+      if (scoreValue >= identityConfig.THRESHOLD_SUSPICIOUS) {
+        const distToAutomation =
+          scoreValue - identityConfig.THRESHOLD_SUSPICIOUS;
+        const distToOrganic = identityConfig.THRESHOLD_HUMAN - scoreValue;
+
+        if (distToAutomation <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+          return "automation";
+        }
+
+        if (distToOrganic <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+          return "organic";
+        }
+
+        return;
+      }
+
+      const dist = identityConfig.THRESHOLD_SUSPICIOUS - scoreValue;
+      return dist <= CLASSIFICATION_PROXIMITY_THRESHOLD ? "mixed" : undefined;
+    },
+  );
+
+  return {
+    nearestClassification,
+  };
+}

--- a/app/composables/useNearestClassification.ts
+++ b/app/composables/useNearestClassification.ts
@@ -19,27 +19,21 @@ export function useNearestClassification(
 
       if (scoreValue >= identityConfig.THRESHOLD_HUMAN) {
         const dist = scoreValue - identityConfig.THRESHOLD_HUMAN;
-        return dist <= CLASSIFICATION_PROXIMITY_THRESHOLD ? "mixed" : undefined;
-      }
 
-      if (scoreValue >= identityConfig.THRESHOLD_SUSPICIOUS) {
-        const distToAutomation =
-          scoreValue - identityConfig.THRESHOLD_SUSPICIOUS;
-        const distToOrganic = identityConfig.THRESHOLD_HUMAN - scoreValue;
-
-        if (distToAutomation <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
-          return "automation";
-        }
-
-        if (distToOrganic <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
-          return "organic";
+        if (dist <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+          return "mixed";
         }
 
         return;
       }
 
-      const dist = identityConfig.THRESHOLD_SUSPICIOUS - scoreValue;
-      return dist <= CLASSIFICATION_PROXIMITY_THRESHOLD ? "mixed" : undefined;
+      if (scoreValue >= identityConfig.THRESHOLD_SUSPICIOUS) {
+        const dist = scoreValue - identityConfig.THRESHOLD_SUSPICIOUS;
+
+        if (dist <= CLASSIFICATION_PROXIMITY_THRESHOLD) {
+          return "automation";
+        }
+      }
     },
   );
 

--- a/shared/types/ecosystem-health.ts
+++ b/shared/types/ecosystem-health.ts
@@ -8,4 +8,5 @@ export type EcosystemHealthItem = {
   user_public_repos_count: number;
   events_count: number;
   repo_name: string;
+  username: string;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a “close to” classification indicator when an analysis score is near another classification.

* **UI Updates**
  * Analysis card header surfaces trend info above the classification label and reorganizes the header layout.
  * Scan list table now displays Username and Score (replacing User ID) and includes those values in aggregated stats.

* **Data**
  * Items now include a username field so tables and aggregations can surface usernames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->