### PR TITLE
feat: add trends in health chart tooltip

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -45,8 +45,13 @@ function composeRawDataset(): VueUiXyDatasetItem[] {
     {
       name: "Organic",
       series:
-        dates.value?.map((date) => countsByDate.value?.[date]?.organic ?? 0) ??
-        [],
+        dates.value?.map(
+          (date) => countsByDate.value?.[date]?.organic.count ?? 0,
+        ) ?? [],
+      trends:
+        dates.value?.map(
+          (date) => countsByDate.value?.[date]?.organic.trend ?? 0,
+        ) ?? [],
       color: colors.value.greenLine,
       type: "line",
       smooth: true,
@@ -55,8 +60,13 @@ function composeRawDataset(): VueUiXyDatasetItem[] {
     {
       name: "Mixed",
       series:
-        dates.value?.map((date) => countsByDate.value?.[date]?.mixed ?? 0) ??
-        [],
+        dates.value?.map(
+          (date) => countsByDate.value?.[date]?.mixed.count ?? 0,
+        ) ?? [],
+      trends:
+        dates.value?.map(
+          (date) => countsByDate.value?.[date]?.mixed.trend ?? 0,
+        ) ?? [],
       color: colors.value.amber,
       type: "line",
       smooth: true,
@@ -66,7 +76,11 @@ function composeRawDataset(): VueUiXyDatasetItem[] {
       name: "Automation",
       series:
         dates.value?.map(
-          (date) => countsByDate.value?.[date]?.automation ?? 0,
+          (date) => countsByDate.value?.[date]?.automation.count ?? 0,
+        ) ?? [],
+      trends:
+        dates.value?.map(
+          (date) => countsByDate.value?.[date]?.automation.trend ?? 0,
         ) ?? [],
       color: colors.value.dangerHover,
       type: "line",
@@ -170,6 +184,15 @@ const config = computed<VueUiXyConfig>(() => ({
     zoom: { show: false },
   },
 }));
+
+function getTrend({ series, item, index }: any) {
+  const trend = series?.[item.slotAbsoluteIndex]?.trends?.[index];
+  return {
+    formattedValue: formatTrend(trend),
+    color: getTrendColor({ value: trend, reversed: item.name !== "Organic" }),
+    arrow: getTrendArrow(trend),
+  };
+}
 </script>
 
 <template>
@@ -184,26 +207,59 @@ const config = computed<VueUiXyConfig>(() => ({
             </linearGradient>
           </template>
 
-          <template #tooltip="{ datapoint, timeLabel }">
+          <template #tooltip="{ datapoint, timeLabel, series }">
             <div class="flex flex-col">
               <div :style="{ color: colors.textMuted }" class="mb-1">
                 {{ timeLabel.text }}
               </div>
               <div
                 class="flex flex-row gap-2 place-items-center"
-                v-for="series in datapoint"
-                :key="`${series.name}-${series.absoluteIndex}`"
+                v-for="dp in datapoint"
+                :key="`${dp.name}-${dp.absoluteIndex}`"
               >
                 <div class="h-2 w-2">
                   <svg viewBox="0 0 2 2" class="w-full h-full">
-                    <circle cx="1" cy="1" r="1" :fill="series.color" />
+                    <circle cx="1" cy="1" r="1" :fill="dp.color" />
                   </svg>
                 </div>
-                <span :style="{ color: colors.text }">{{ series.name }}</span>
+                <span :style="{ color: colors.text }">{{ dp.name }}</span>
                 <span :style="{ color: colors.textMuted }">{{
-                  series.value +
-                  (series.slotAbsoluteIndex === dataset.length - 1 ? "%" : "")
+                  dp.value +
+                  (dp.slotAbsoluteIndex === dataset.length - 1 ? "%" : "")
                 }}</span>
+
+                <!-- No trend is possible on the first datapoint -->
+                <template v-if="timeLabel.absoluteIndex > 0">
+                  <span
+                    :class="[
+                      getTrend({
+                        series,
+                        item: dp,
+                        index: timeLabel.absoluteIndex,
+                      }).color,
+                    ]"
+                    v-if="dp.slotAbsoluteIndex < series.length - 1"
+                  >
+                    <span
+                      :class="[
+                        getTrend({
+                          series,
+                          item: dp,
+                          index: timeLabel.absoluteIndex,
+                        }).arrow,
+                      ]"
+                      class="shrink-0"
+                      style="vertical-align: middle"
+                    />
+                    {{
+                      getTrend({
+                        series,
+                        item: dp,
+                        index: timeLabel.absoluteIndex,
+                      }).formattedValue
+                    }}</span
+                  >
+                </template>
               </div>
             </div>
           </template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -127,11 +127,17 @@ const config = computed<VueUiXyConfig>(() => ({
     threshold: 5000,
   },
   line: {
-    radius: Number.MIN_VALUE, // bug in the lib, 0 does not work
+    radius: 0,
+    useGradient: false,
+    dot: {
+      useSerieColor: true,
+      fill: colors.value.bg,
+      strokeWidth: 2,
+    },
   },
   chart: {
     userOptions: { show: false },
-    backgroundColor: "transparent",
+    backgroundColor: colors.value.bg,
     color: colors.value.textMuted,
     width: width.value,
     height: height.value,

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -178,7 +178,9 @@ function getTooltipContent(
   const eligible = datapoint?.details?.eligiblePrs?.[index];
   const closed = datapoint?.details?.closedPrs?.[index];
   if (closed == null || eligible == null) return "";
-  return `${closed} / ${eligible} (${Math.round((closed / (eligible || 1)) * 100)}%)`;
+  const percentage =
+    eligible === 0 ? 100 : Math.round((closed / eligible) * 100);
+  return `${closed} / ${eligible} (${percentage}%)`;
 }
 
 function hideDataLabel(chartIndex: number) {

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -7,12 +7,27 @@ import {
   type VueUiXyTooltipSlotProps,
 } from "vue-data-ui/vue-ui-xy";
 import { identityConfig } from "@unveil/identity";
+import { useTimeoutFn } from "@vueuse/core";
 
 import("vue-data-ui/style.css");
 
 const { data } = useEcosystemHealth();
+const dates = computed(() => data.value?.dates);
+
 const rootEl = shallowRef<HTMLElement | null>(null);
 const colors = useColors(rootEl);
+
+const loaded = shallowRef(false);
+
+const { start } = useTimeoutFn(
+  () => {
+    loaded.value = true;
+  },
+  250,
+  { immediate: false },
+);
+
+onMounted(start);
 
 const scoreBounds = shallowRef<ScoreBounds>([
   0,
@@ -41,16 +56,32 @@ const sparklines = computed(() => {
     return dataset.map((datapoint) => ({
       ...datapoint,
       color: colors.value.textTransparent,
+      dataLabels: false,
+      suffix: "%",
     }));
   });
 });
 
+const selectedIndex = shallowRef<number | undefined>(undefined);
+const selectedChartIndex = shallowRef<number | undefined>(undefined);
+
 const config = computed<VueUiXyConfig>(() => ({
   useCssAnimation: false,
+  events: {
+    datapointEnter: ({ seriesIndex }) => {
+      selectedIndex.value = seriesIndex;
+    },
+    datapointLeave: () => {
+      selectedIndex.value = undefined;
+    },
+  },
   chart: {
     userOptions: { show: false },
     legend: { show: false },
     zoom: { show: false },
+    labels: {
+      fontSize: 16,
+    },
     tooltip: {
       show: true,
       teleportTo: "#sparklines",
@@ -70,7 +101,7 @@ const config = computed<VueUiXyConfig>(() => ({
       right: 66,
       bottom: 0,
     },
-    backgroundColor: "transparent",
+    backgroundColor: colors.value.bg,
     height: 100,
     width: 450,
     grid: {
@@ -80,6 +111,19 @@ const config = computed<VueUiXyConfig>(() => ({
         show: false,
         xAxisLabels: {
           show: false,
+          values: dates.value,
+          datetimeFormatter: {
+            enable: true,
+            useUTC: true,
+            locale: "en",
+            options: {
+              year: "dd MMM",
+              month: "dd MMM",
+              day: "dd MMM",
+              minute: "dd MMM",
+              second: "dd MMM",
+            },
+          },
         },
         yAxis: {
           scaleMin: 0,
@@ -89,7 +133,19 @@ const config = computed<VueUiXyConfig>(() => ({
     },
   },
   line: {
-    radius: Number.MIN_VALUE,
+    radius: 0,
+    useGradient: false,
+    dot: {
+      useSerieColor: false,
+      fill: selectedRangeColor.value,
+      strokeWidth: 3,
+      selectedRadius: 6,
+    },
+    labels: {
+      show: true,
+      color: colors.value.text,
+      offsetY: -12,
+    },
   },
 }));
 
@@ -122,7 +178,15 @@ function getTooltipContent(
   const eligible = datapoint?.details?.eligiblePrs?.[index];
   const closed = datapoint?.details?.closedPrs?.[index];
   if (closed == null || eligible == null) return "";
-  return `${closed} / ${eligible}`;
+  return `${closed} / ${eligible} (${Math.round((closed / (eligible || 1)) * 100)}%)`;
+}
+
+function hideDataLabel(chartIndex: number) {
+  return (
+    selectedChartIndex.value === chartIndex ||
+    (selectedIndex.value !== undefined &&
+      selectedIndex.value === (dates.value?.length ?? 0) - 1)
+  );
 }
 </script>
 
@@ -179,8 +243,12 @@ function getTooltipContent(
     </label>
   </div>
 
-  <div class="grid grid-cols-2 gap-4 max-w-[600px] mx-auto" id="sparklines">
-    <ClientOnly v-for="chart in sparklines" :key="chart[0]?.name">
+  <div
+    class="grid grid-cols-2 gap-4 max-w-[600px] mx-auto"
+    id="sparklines"
+    :data-loaded="loaded"
+  >
+    <ClientOnly v-for="(chart, chartIndex) in sparklines" :key="chart[0]?.name">
       <div class="flex flex-col">
         <div class="text-sm mb-1">
           <span class="text-gh-muted">{{ chart[0]?.name.split("/")[0] }}/</span>
@@ -190,10 +258,17 @@ function getTooltipContent(
         <div
           class="w-full h-full border-gh-border border-l border-b rounded-bl"
           v-if="chart[0]?.hasData"
+          :data-hide-label="hideDataLabel(chartIndex)"
         >
-          <VueUiXy :dataset="chart" :config="config">
+          <VueUiXy
+            :dataset="chart"
+            :config
+            :selected-x-index="selectedIndex"
+            @mouseenter="selectedChartIndex = chartIndex"
+          >
             <template #tooltip="{ series, timeLabel }">
-              <div class="text-gh-muted">
+              <div class="text-gh-muted flex flex-col text-center text-xs">
+                <span>{{ timeLabel.text }}</span>
                 {{ getTooltipContent(series, timeLabel) }}
               </div>
             </template>
@@ -248,11 +323,21 @@ function getTooltipContent(
   --super-ease-out: cubic-bezier(0.15, 0.75, 0.35, 1);
 }
 
-:deep(.vue-data-ui-component path),
-:deep(.last-datapoint),
-:deep(.value-label),
-:deep(.value-plot) {
+[data-loaded="true"] :deep(.vue-data-ui-component path),
+[data-loaded="true"] :deep(.last-datapoint),
+[data-loaded="true"] :deep(.value-label),
+[data-loaded="true"] :deep(.value-plot) {
   transition: all 0.5s var(--super-ease-out) !important;
+}
+
+[data-loaded="false"] :deep(.vue-data-ui-component path),
+[data-loaded="false"] :deep(.last-datapoint),
+[data-loaded="false"] :deep(.value-label),
+[data-loaded="false"] :deep(.value-plot) {
+  transition: none !important;
+}
+:deep(.vue-data-ui-component circle) {
+  stroke: var(--bg);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -262,6 +347,10 @@ function getTooltipContent(
   :deep(.value-plot) {
     transition: none !important;
   }
+}
+
+:deep([data-hide-label="true"] svg text:not(.value-label)) {
+  display: none;
 }
 </style>
 

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -21,21 +21,21 @@ function createChartDataset(): {
       {
         name: "Organic",
         series: dates.value.map(
-          (date) => data.value?.countsByDate?.[date]?.organic ?? 0,
+          (date) => data.value?.countsByDate?.[date]?.organic.count ?? 0,
         ),
         color: colors.value.greenLine,
       },
       {
         name: "Mixed",
         series: dates.value.map(
-          (date) => data.value?.countsByDate?.[date]?.mixed ?? 0,
+          (date) => data.value?.countsByDate?.[date]?.mixed.count ?? 0,
         ),
         color: colors.value.amber,
       },
       {
         name: "Automation",
         series: dates.value.map(
-          (date) => data.value?.countsByDate?.[date]?.automation ?? 0,
+          (date) => data.value?.countsByDate?.[date]?.automation.count ?? 0,
         ),
         color: colors.value.dangerHover,
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.21.1",
+        "vue-data-ui": "^3.21.4",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -2351,6 +2351,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2368,6 +2369,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2385,6 +2387,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2402,6 +2405,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2419,6 +2423,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2436,6 +2441,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2453,6 +2459,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2470,6 +2477,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2487,6 +2495,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2504,6 +2513,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2521,6 +2531,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2538,6 +2549,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2555,6 +2567,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2572,6 +2585,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2589,6 +2603,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2606,6 +2621,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2623,6 +2639,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -2642,6 +2659,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2659,6 +2677,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2676,6 +2695,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4591,6 +4611,30 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@unocss/nuxt/node_modules/@unocss/astro": {
+      "version": "66.6.7",
+      "resolved": "https://registry.npmjs.org/@unocss/astro/-/astro-66.6.7.tgz",
+      "integrity": "sha512-Vk/4sZWGgusROqL4eMgp3uZVYDDdfknNPyn1ij1dNPw2HV/m79U4QKpjpZvnr9XwrX9i4CMgc1TcZdC9T4gzuA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@unocss/core": "66.6.7",
+        "@unocss/reset": "66.6.7",
+        "@unocss/vite": "66.6.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@unocss/nuxt/node_modules/@unocss/cli": {
       "version": "66.6.7",
       "resolved": "https://registry.npmjs.org/@unocss/cli/-/cli-66.6.7.tgz",
@@ -4681,6 +4725,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@unocss/nuxt/node_modules/@unocss/postcss": {
+      "version": "66.6.7",
+      "resolved": "https://registry.npmjs.org/@unocss/postcss/-/postcss-66.6.7.tgz",
+      "integrity": "sha512-ArXEkhP2czxkeKQKI7RqmZiw3n8Kj6AR+WIssta/KgLRefEbYHJht3a2qgP739a1uSDYnvn19SN40+i7TCpKrg==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@unocss/config": "66.6.7",
+        "@unocss/core": "66.6.7",
+        "@unocss/rule-utils": "66.6.7",
+        "css-tree": "^3.1.0",
+        "postcss": "^8.5.6",
+        "tinyglobby": "^0.2.15"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
       }
     },
     "node_modules/@unocss/nuxt/node_modules/@unocss/preset-attributify": {
@@ -13855,9 +13924,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.1.tgz",
-      "integrity": "sha512-iInl5SNpQXuCF5pGrzJkdr83kfYevUP3slu9d4QMSK1qNc8WejLYeC/HHDDobei7hJvUqy8zSuZt/4vs7lhxWw==",
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.4.tgz",
+      "integrity": "sha512-h+nVqKSlrJnqgWyeHHoVNmf8tbQrksoGDiQ0CFLYL5a3wmigS++coL7ydA46Wbto2++wBGGAIgn7hp+UGXgidw==",
       "peerDependencies": {
         "jspdf": ">=3.0.1",
         "vue": ">=3.3.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.21.1",
+    "vue-data-ui": "^3.21.4",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/server/api/health.get.ts
+++ b/server/api/health.get.ts
@@ -31,9 +31,15 @@ export default defineEventHandler(async () => {
 
     dates.forEach((date) => {
       const counts = countsByDate[date];
-      automation.push(counts?.automation ?? 0);
-      mixed.push(counts?.mixed ?? 0);
-      organic.push(counts?.organic ?? 0);
+      if (!counts) return;
+
+      automation.push(counts.automation.count);
+      mixed.push(counts.mixed.count);
+      organic.push(counts.organic.count);
+
+      counts.automation.trend = calcLinearProgression(automation).trend;
+      counts.mixed.trend = calcLinearProgression(mixed).trend;
+      counts.organic.trend = calcLinearProgression(organic).trend;
     });
 
     const categoryProgression: EcosystemHealthCategoryProgression = {

--- a/shared/utils/count-classification-by-date.ts
+++ b/shared/utils/count-classification-by-date.ts
@@ -1,8 +1,17 @@
 import { identityConfig } from "@unveil/identity";
 
+type CountWithTrend = {
+  count: number;
+  trend: number;
+};
+
 type CountClassificationByDateResults = Record<
   string,
-  EcosystemHealthCategoryCounts
+  {
+    automation: CountWithTrend;
+    mixed: CountWithTrend;
+    organic: CountWithTrend;
+  }
 >;
 
 export function countClassificationByDate(
@@ -14,9 +23,9 @@ export function countClassificationByDate(
 
   dates.forEach((date) => {
     result[date] = {
-      automation: 0,
-      mixed: 0,
-      organic: 0,
+      automation: { count: 0, trend: 0 },
+      mixed: { count: 0, trend: 0 },
+      organic: { count: 0, trend: 0 },
     };
   });
 
@@ -28,11 +37,11 @@ export function countClassificationByDate(
     }
 
     if (item.score >= identityConfig.THRESHOLD_HUMAN) {
-      dateCounts.organic += 1;
+      dateCounts.organic.count += 1;
     } else if (item.score >= identityConfig.THRESHOLD_SUSPICIOUS) {
-      dateCounts.mixed += 1;
+      dateCounts.mixed.count += 1;
     } else {
-      dateCounts.automation += 1;
+      dateCounts.automation.count += 1;
     }
   });
 


### PR DESCRIPTION
This adds progression trends in the health chart's tooltip.
Trends correspond to the state at the given date (from 0 to the selected index).

<img width="388" height="243" alt="image" src="https://github.com/user-attachments/assets/8310a1b5-6807-4b13-96fd-2e1277a85b89" />

To that end, the countByDate endpoint was modified to return objects with count and trend (with impacts where the simple count was used before). This might be handy if we ever need to add more daily info in the future.

## Other
- update vue-data-ui to latest ([release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.21.4))
- show dots on health chart when hovering the chart
- various improvements on the lab sparklines:
  - sync selected indices across all chart instances
  - show dot on the chart when a selection is active
  - show percent data labels on all chart instances when a selection is active
  - improve tooltip content
  - mute path transitions on load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Chart tooltips now include per-category trend indicators (arrows with formatted progression values).

* **Updates**
  * Refined time-series chart series/stacking to consistently align counts and trends across dates.
  * Updated chart and sparkline visuals (background, dot/label rendering, tooltip details, and smoother loaded transitions).
  * Improved lab page chart data sourcing to use count values per date/category.

* **Bug Fixes**
  * Health endpoint now skips dates when count data is missing, avoiding partial defaulting.

* **Chores**
  * Bumped the `vue-data-ui` dependency patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->