### PR TITLE
fix: datapoint circles not transitioned

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -578,28 +578,6 @@ function getZapIconPath({ x, y }: { x: number; y: number }) {
 </template>
 
 <style scoped>
-:deep(.vue-data-ui-component) {
-  --super-ease-out: cubic-bezier(0.15, 0.75, 0.35, 1);
-}
-
-:deep(.vue-data-ui-component .serie_line_0 path),
-:deep(.vue-data-ui-component .serie_line_1 path),
-:deep(.vue-data-ui-component .serie_line_2 path),
-:deep(.vue-data-ui-component .serie_line_3 path),
-:deep(.vdui-shape-circle) {
-  transition: all 0.5s var(--super-ease-out) !important;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  :deep(.vue-data-ui-component .serie_line_0 path),
-  :deep(.vue-data-ui-component .serie_line_1 path),
-  :deep(.vue-data-ui-component .serie_line_2 path),
-  :deep(.vue-data-ui-component .serie_line_3 path),
-  :deep(.vdui-shape-circle) {
-    transition: none !important;
-  }
-}
-
 :deep(.vue-ui-xy-annotation-label) {
   stroke: var(--bg);
   stroke-width: 4;

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -164,7 +164,7 @@ const config = computed<VueUiXyConfig>(() => ({
             options: {
               year: "dd MMM",
               month: "dd MMM",
-              day: "MMM dd • hh:mm",
+              day: "MMM dd • HH:mm",
               minute: "dd MMM",
               second: "dd MMM",
             },

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -342,6 +342,10 @@ function hideDataLabel(chartIndex: number) {
   stroke: var(--bg);
 }
 
+:deep(.vdui-shape-circle) {
+  transition: none !important;
+}
+
 @media (prefers-reduced-motion: reduce) {
   :deep(.vue-data-ui-component path),
   :deep(.last-datapoint),

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.21.7",
+        "vue-data-ui": "^3.21.8",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13924,9 +13924,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.21.7",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.7.tgz",
-      "integrity": "sha512-41+gF4z17npyZgs6GZ1yet1v5hzl7Qq4fcqoxAOoBMupbQ1LD284748ru7BsVslbvSaLfI5If6dybyPGLyu73Q==",
+      "version": "3.21.8",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.8.tgz",
+      "integrity": "sha512-YO7GYmGRU5YiEGDV4JLZ2smfs13nhgjwwwwT3F5Xk6T1QPaI/O3bABvD36o8BJWdyUKGtEap1B/mjFKU5AQBVg==",
       "peerDependencies": {
         "jspdf": ">=3.0.1",
         "vue": ">=3.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.21.4",
+        "vue-data-ui": "^3.21.5",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13924,9 +13924,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.4.tgz",
-      "integrity": "sha512-h+nVqKSlrJnqgWyeHHoVNmf8tbQrksoGDiQ0CFLYL5a3wmigS++coL7ydA46Wbto2++wBGGAIgn7hp+UGXgidw==",
+      "version": "3.21.5",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.5.tgz",
+      "integrity": "sha512-+aIsMphMdTdWpNncgflZlJO2ZsyAvzJbYkCTn9g89o8YYW4PpGS5DbO5aKwEo1Nho2DsBSTtKRp6vVY9PelYuw==",
       "peerDependencies": {
         "jspdf": ">=3.0.1",
         "vue": ">=3.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.21.8",
+        "vue-data-ui": "^3.21.9",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13924,9 +13924,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.8.tgz",
-      "integrity": "sha512-YO7GYmGRU5YiEGDV4JLZ2smfs13nhgjwwwwT3F5Xk6T1QPaI/O3bABvD36o8BJWdyUKGtEap1B/mjFKU5AQBVg==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.9.tgz",
+      "integrity": "sha512-Ht0oBVP/QAxMmXWsoUJYRdaQU1jfYsMlZV7IYuPialN8cBoqEN34i13ys25DvdjTPuaKmuv7tYNzfFeCm5ITFQ==",
       "peerDependencies": {
         "jspdf": ">=3.0.1",
         "vue": ">=3.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "octokit": "^5.0.5",
         "valibot": "^1.2.0",
         "vue": "^3.5.28",
-        "vue-data-ui": "^3.21.5",
+        "vue-data-ui": "^3.21.7",
         "vue-router": "^4.6.4"
       },
       "devDependencies": {
@@ -13924,9 +13924,9 @@
       }
     },
     "node_modules/vue-data-ui": {
-      "version": "3.21.5",
-      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.5.tgz",
-      "integrity": "sha512-+aIsMphMdTdWpNncgflZlJO2ZsyAvzJbYkCTn9g89o8YYW4PpGS5DbO5aKwEo1Nho2DsBSTtKRp6vVY9PelYuw==",
+      "version": "3.21.7",
+      "resolved": "https://registry.npmjs.org/vue-data-ui/-/vue-data-ui-3.21.7.tgz",
+      "integrity": "sha512-41+gF4z17npyZgs6GZ1yet1v5hzl7Qq4fcqoxAOoBMupbQ1LD284748ru7BsVslbvSaLfI5If6dybyPGLyu73Q==",
       "peerDependencies": {
         "jspdf": ">=3.0.1",
         "vue": ">=3.3.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.21.5",
+    "vue-data-ui": "^3.21.7",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.21.7",
+    "vue-data-ui": "^3.21.8",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.21.8",
+    "vue-data-ui": "^3.21.9",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "octokit": "^5.0.5",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.21.4",
+    "vue-data-ui": "^3.21.5",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes the circles not transitioned when filtering out series on the profile graph.
Vue Data Ui was updated to latest.

I also fixed an impact on the sparklines, where transitions were unwanted when hovering the charts.

Before:

https://github.com/user-attachments/assets/d6b3307f-c1b1-416a-bd27-165d9958d77f

After:

https://github.com/user-attachments/assets/daa7b25b-5b09-4c5b-97fd-1952d0a2c6ea






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined chart annotation label styling (stroke, stroke width, and rendering order).
  * Disabled chart circle CSS transitions to prevent unintended motion during updates.

* **Updates**
  * Switched chart x-axis time labels to 24-hour format for clearer consistency.
  * Updated the chart library dependency to a newer patch version for improved rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->