### PR TITLE
feat: improve discord stats

### DIFF
--- a/scripts/notify-discord.ts
+++ b/scripts/notify-discord.ts
@@ -1,9 +1,15 @@
 /// <reference types="node" />
 import { readFileSync } from "node:fs";
-import { getHealthStats, formatTrend } from "../shared/utils/health-stats";
-import { getClosedPrPercentageTotal } from "../shared/utils/charts";
+import { formatTrend } from "../shared/utils/health-stats";
+import {
+  getClosedPrPercentageTotal,
+  getClosedPrDelta,
+} from "../shared/utils/charts";
 import { calcLinearProgression } from "../shared/utils/calc-linear-progression";
-import { countClassificationByDate } from "../shared/utils/count-classification-by-date";
+import {
+  countClassificationByDate,
+  getCategoryDeltas,
+} from "../shared/utils/count-classification-by-date";
 
 async function main() {
   const results = JSON.parse(readFileSync("data/scan-results.json", "utf-8"));
@@ -13,15 +19,11 @@ async function main() {
     return;
   }
 
-  const stats = getHealthStats(results);
-
-  if (!stats) {
-    console.log("No stats");
-    return;
-  }
-
-  const value = getClosedPrPercentageTotal(results, [0, 50]);
-  const percentage = value === null ? "N/A" : `${value}%`;
+  const closedAutomationPrPercentage = getClosedPrPercentageTotal(
+    results,
+    [0, 50],
+  );
+  const closedAutomationPrDelta = getClosedPrDelta(results, [0, 50]);
 
   const automation: number[] = [];
   const mixed: number[] = [];
@@ -44,20 +46,33 @@ async function main() {
     organic: calcLinearProgression(organic),
   };
 
+  const categoryDeltas = getCategoryDeltas(results);
+
   function trendLabel(trendValue: number): string {
     const arrow = trendValue > 0 ? "↑" : trendValue < 0 ? "↓" : "→";
-    return `${arrow} ${formatTrend(trendValue)}`;
+    return `${arrow} ${formatTrend(trendValue)} overall`;
+  }
+
+  function statLabel(value: number | null, suffix = ""): string {
+    if (value == null || !isFinite(value)) return "N/A";
+    const arrow = value > 0 ? "↑" : value < 0 ? "↓" : "→";
+    const sign = value > 0 ? "+" : "";
+    return `${arrow} ${sign}${value}${suffix}`;
+  }
+
+  function percentageLabel(value: number | null): string {
+    return value === null ? "N/A" : `${value}%`;
   }
 
   const payload = {
     content: [
       "Daily Dose of Clankers",
       "",
-      `🟢 Organic ${stats.organic.percentage}% ${trendLabel(categoryProgression.organic.trend)}`,
-      `🟡 Mixed ${stats.mixed.percentage}% ${trendLabel(categoryProgression.mixed.trend)}`,
-      `🔴 Automation ${stats.automation.percentage}% ${trendLabel(categoryProgression.automation.trend)}`,
+      `🟢 Organic ${percentageLabel(categoryDeltas.organic.lastPercentage)} ${statLabel(categoryDeltas.organic.percentagePointDifference, " pts")} (${trendLabel(categoryProgression.organic.trend)})`,
+      `🟡 Mixed ${percentageLabel(categoryDeltas.mixed.lastPercentage)} ${statLabel(categoryDeltas.mixed.percentagePointDifference, " pts")} (${trendLabel(categoryProgression.mixed.trend)})`,
+      `🔴 Automation ${percentageLabel(categoryDeltas.automation.lastPercentage)} ${statLabel(categoryDeltas.automation.percentagePointDifference, " pts")} (${trendLabel(categoryProgression.automation.trend)})`,
       "",
-      `⚫ Automation PR closure rate ${percentage}`,
+      `⚫ Automation PR closure rate ${percentageLabel(closedAutomationPrDelta.lastSnapshot.percentage)} ${statLabel(closedAutomationPrDelta.percentagePointDifference, " pts")} (${percentageLabel(closedAutomationPrPercentage)} overall)`,
     ].join("\n"),
   };
 

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -325,3 +325,92 @@ export function getClosedPrPercentageTotal(
   if (totalEligible === 0) return 100;
   return Math.round((totalClosed / totalEligible) * 100);
 }
+
+export type ClosedPrPercentageSnapshot = {
+  date: string | undefined;
+  eligiblePrs: number | null;
+  closedPrs: number | null;
+  percentage: number | null;
+};
+
+export type ClosedPrPercentageComparison = {
+  previousSnapshot: ClosedPrPercentageSnapshot;
+  lastSnapshot: ClosedPrPercentageSnapshot;
+  percentagePointDifference: number | null;
+};
+
+export function getClosedPrSnapshot(
+  source: EcosystemHealthItem[] = [],
+  date: string | Date | undefined,
+  scoreBounds: ScoreBounds = [0, 100],
+  dateKey: keyof EcosystemHealthItem = "created_at",
+): ClosedPrPercentageSnapshot {
+  if (!date) {
+    return {
+      date: undefined,
+      eligiblePrs: null,
+      closedPrs: null,
+      percentage: null,
+    };
+  }
+
+  const results = getClosedPrPercentageByRepoForDate(source, date, {
+    scoreBounds,
+    dateKey,
+  });
+
+  const eligiblePrs = results.reduce(
+    (total, result) => total + result.eligiblePrs,
+    0,
+  );
+
+  const closedPrs = results.reduce(
+    (total, result) => total + result.closedPrs,
+    0,
+  );
+
+  return {
+    date: getDayKey(date),
+    eligiblePrs,
+    closedPrs,
+    // no eligible PRs = 100% closure rate
+    percentage:
+      eligiblePrs === 0 ? 100 : Math.round((closedPrs / eligiblePrs) * 100),
+  };
+}
+
+export function getClosedPrDelta(
+  source: EcosystemHealthItem[] = [],
+  scoreBounds: ScoreBounds = [0, 100],
+  dateKey: keyof EcosystemHealthItem = "created_at",
+): ClosedPrPercentageComparison {
+  const dates = getUniqueDatesFromSource(source, dateKey);
+
+  const previousDate = dates.at(-2);
+  const lastDate = dates.at(-1);
+
+  const previousSnapshot = getClosedPrSnapshot(
+    source,
+    previousDate,
+    scoreBounds,
+    dateKey,
+  );
+
+  const lastSnapshot = getClosedPrSnapshot(
+    source,
+    lastDate,
+    scoreBounds,
+    dateKey,
+  );
+
+  return {
+    previousSnapshot,
+    lastSnapshot,
+    percentagePointDifference:
+      previousSnapshot.percentage == null || lastSnapshot.percentage == null
+        ? null
+        : Math.round(
+            (lastSnapshot.percentage - previousSnapshot.percentage) * 10,
+          ) / 10,
+  };
+}

--- a/shared/utils/count-classification-by-date.ts
+++ b/shared/utils/count-classification-by-date.ts
@@ -1,18 +1,17 @@
-import { identityConfig } from "@unveil/identity";
+import { identityConfig, type IdentityClassification } from "@unveil/identity";
 
 type CountWithTrend = {
   count: number;
   trend: number;
 };
 
-type CountClassificationByDateResults = Record<
-  string,
-  {
-    automation: CountWithTrend;
-    mixed: CountWithTrend;
-    organic: CountWithTrend;
-  }
->;
+type ClassificationCounts = {
+  automation: CountWithTrend;
+  mixed: CountWithTrend;
+  organic: CountWithTrend;
+};
+
+type CountClassificationByDateResults = Record<string, ClassificationCounts>;
 
 export function countClassificationByDate(
   data: EcosystemHealthItem[] = [],
@@ -46,4 +45,100 @@ export function countClassificationByDate(
   });
 
   return result;
+}
+const classificationCategories = ["organic", "mixed", "automation"] as const;
+
+type CategoryPercentageComparison = {
+  category: IdentityClassification;
+  lastDate: string | undefined;
+  lastCount: number | null;
+  lastTotal: number | null;
+  lastPercentage: number | null;
+  previousDate: string | undefined;
+  previousCount: number | null;
+  previousTotal: number | null;
+  previousPercentage: number | null;
+  percentagePointDifference: number | null;
+};
+
+type CategoryPercentageComparisons = Record<
+  IdentityClassification,
+  CategoryPercentageComparison
+>;
+
+function getTotalClassificationCount(
+  counts: ClassificationCounts | undefined,
+): number | null {
+  if (!counts) return null;
+  return classificationCategories.reduce(
+    (total, category) => total + counts[category].count,
+    0,
+  );
+}
+
+function getCategoryPercentageFromCounts(
+  counts: ClassificationCounts | undefined,
+  category: IdentityClassification,
+): number | null {
+  const total = getTotalClassificationCount(counts);
+  if (!counts || !total) return null;
+  return Number(((counts[category].count / total) * 100).toFixed(2));
+}
+
+function getCategoryPercentageComparison({
+  category,
+  lastDate,
+  previousDate,
+  countsByDate,
+}: {
+  category: IdentityClassification;
+  lastDate: string | undefined;
+  previousDate: string | undefined;
+  countsByDate: CountClassificationByDateResults;
+}): CategoryPercentageComparison {
+  const previousCounts = previousDate ? countsByDate[previousDate] : undefined;
+  const lastCounts = lastDate ? countsByDate[lastDate] : undefined;
+  const previousPercentage = getCategoryPercentageFromCounts(
+    previousCounts,
+    category,
+  );
+
+  const lastPercentage = getCategoryPercentageFromCounts(lastCounts, category);
+
+  return {
+    category,
+
+    previousDate,
+    previousCount: previousCounts?.[category].count ?? null,
+    previousTotal: getTotalClassificationCount(previousCounts),
+    previousPercentage,
+
+    lastDate,
+    lastCount: lastCounts?.[category].count ?? null,
+    lastTotal: getTotalClassificationCount(lastCounts),
+    lastPercentage,
+
+    percentagePointDifference:
+      previousPercentage === null || lastPercentage === null
+        ? null
+        : Math.round((lastPercentage - previousPercentage) * 10) / 10,
+  };
+}
+
+export function getCategoryDeltas(
+  results: EcosystemHealthItem[],
+): CategoryPercentageComparisons {
+  const countsByDate = countClassificationByDate(results);
+  const dates = Object.keys(countsByDate).sort();
+  const previousDate = dates.at(-2);
+  const lastDate = dates.at(-1);
+  return classificationCategories.reduce((comparisons, category) => {
+    comparisons[category] = getCategoryPercentageComparison({
+      category,
+      lastDate,
+      previousDate,
+      countsByDate,
+    });
+    return comparisons;
+  }, {} as CategoryPercentageComparisons);
 }

--- a/test/unit/shared/utils/charts.test.ts
+++ b/test/unit/shared/utils/charts.test.ts
@@ -8,11 +8,13 @@ import {
   getClosedPrPercentageEvolutionByRepo,
   getClosedPrPercentageEvolutionTotal,
   getClosedPrPercentageTotal,
+  getClosedPrDelta,
 } from "../../../../shared/utils/charts";
 import {
   EXPECTED_NB_UNIQUE_REPOS,
   MOCK_ECOSYSTEM_HEALTH_ITEMS,
 } from "../../mocks/ecosystemHealthItems";
+import { EcosystemHealthItem } from "../../../../shared/types/ecosystem-health";
 
 describe("getCompleteDayRange", () => {
   it("returns an empty array for an empty array in input", () => {
@@ -206,5 +208,119 @@ describe("getClosedPrPercentageTotal", () => {
   it("returns the total percentage of closed PRs", () => {
     const result = getClosedPrPercentageTotal(MOCK_ECOSYSTEM_HEALTH_ITEMS);
     expect(result).toEqual(40);
+  });
+});
+
+describe("getClosedPrDelta", () => {
+  const previousDate = "2026-05-25T10:00:00.000Z";
+  const lastDate = "2026-05-26T10:00:00.000Z";
+
+  function createEcosystemHealthItem(
+    created_at: string,
+    repo_name: string,
+    pr_number: number,
+    pr_status: "open" | "closed",
+    score: number,
+  ): EcosystemHealthItem {
+    return {
+      created_at,
+      repo_name,
+      pr_number,
+      pr_status,
+      score,
+    } as EcosystemHealthItem;
+  }
+
+  it("returns closed PR percentage snapshots for the previous and last dates", () => {
+    const result = getClosedPrDelta([
+      createEcosystemHealthItem(lastDate, "some/repo", 1, "closed", 25),
+      createEcosystemHealthItem(lastDate, "someother/repo", 2, "closed", 25),
+      createEcosystemHealthItem(previousDate, "some/repo", 1, "closed", 25),
+      createEcosystemHealthItem(previousDate, "someother/repo", 2, "open", 25),
+    ]);
+
+    expect(result).toEqual({
+      previousSnapshot: expect.objectContaining({
+        date: expect.any(String),
+        eligiblePrs: expect.any(Number),
+        closedPrs: expect.any(Number),
+        percentage: expect.any(Number),
+      }),
+      lastSnapshot: expect.objectContaining({
+        date: expect.any(String),
+        eligiblePrs: expect.any(Number),
+        closedPrs: expect.any(Number),
+        percentage: expect.any(Number),
+      }),
+      percentagePointDifference: expect.any(Number),
+    });
+  });
+
+  it("calculates accurate closed PR percentages and point difference", () => {
+    const result = getClosedPrDelta([
+      createEcosystemHealthItem(lastDate, "some/repo", 1, "closed", 25),
+      createEcosystemHealthItem(lastDate, "someother/repo", 2, "closed", 25),
+      createEcosystemHealthItem(previousDate, "some/repo", 1, "closed", 25),
+      createEcosystemHealthItem(previousDate, "someother/repo", 2, "open", 25),
+    ]);
+
+    expect(result.previousSnapshot).toEqual({
+      date: "2026-05-25",
+      eligiblePrs: 2,
+      closedPrs: 1,
+      percentage: 50,
+    });
+
+    expect(result.lastSnapshot).toEqual({
+      date: "2026-05-26",
+      eligiblePrs: 2,
+      closedPrs: 2,
+      percentage: 100,
+    });
+
+    expect(result.percentagePointDifference).toBe(50);
+  });
+
+  it("returns null previous values when there is only one date", () => {
+    const result = getClosedPrDelta([
+      createEcosystemHealthItem(lastDate, "some/repo", 1, "closed", 25),
+      createEcosystemHealthItem(lastDate, "someother/repo", 2, "open", 25),
+    ]);
+
+    expect(result.previousSnapshot).toEqual({
+      date: undefined,
+      eligiblePrs: null,
+      closedPrs: null,
+      percentage: null,
+    });
+
+    expect(result.lastSnapshot).toEqual({
+      date: "2026-05-26",
+      eligiblePrs: 2,
+      closedPrs: 1,
+      percentage: 50,
+    });
+
+    expect(result.percentagePointDifference).toBeNull();
+  });
+
+  it("returns null snapshots when the source is empty", () => {
+    const result = getClosedPrDelta([]);
+
+    expect(result).toEqual({
+      previousSnapshot: {
+        date: undefined,
+        eligiblePrs: null,
+        closedPrs: null,
+        percentage: null,
+      },
+      lastSnapshot: {
+        date: undefined,
+        eligiblePrs: null,
+        closedPrs: null,
+        percentage: null,
+      },
+      percentagePointDifference: null,
+    });
   });
 });

--- a/test/unit/shared/utils/count-classification-by-date.test.ts
+++ b/test/unit/shared/utils/count-classification-by-date.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { countClassificationByDate } from "../../../../shared/utils/count-classification-by-date";
+import {
+  countClassificationByDate,
+  getCategoryDeltas,
+} from "../../../../shared/utils/count-classification-by-date";
 import { MOCK_ECOSYSTEM_HEALTH_ITEMS } from "../../mocks/ecosystemHealthItems";
+import { EcosystemHealthItem } from "../../../../shared/types/ecosystem-health";
 
 describe("countClassificationByDate", () => {
   const result = countClassificationByDate(MOCK_ECOSYSTEM_HEALTH_ITEMS);
@@ -30,5 +34,186 @@ describe("countClassificationByDate", () => {
         }),
       );
     });
+  });
+});
+
+describe("getCategoryDeltas", () => {
+  const previousDate = "2026-06-18T11:38:32.093Z";
+  const lastDate = "2026-06-19T14:37:04.644Z";
+
+  function createEcosystemHealthItem(
+    created_at: string,
+    score: number,
+  ): EcosystemHealthItem {
+    return {
+      created_at,
+      score,
+    } as EcosystemHealthItem;
+  }
+
+  it("returns category deltas keyed by category", () => {
+    const result = getCategoryDeltas([
+      createEcosystemHealthItem(lastDate, 90),
+      createEcosystemHealthItem(lastDate, 50),
+      createEcosystemHealthItem(lastDate, 10),
+      createEcosystemHealthItem(previousDate, 90),
+      createEcosystemHealthItem(previousDate, 50),
+      createEcosystemHealthItem(previousDate, 10),
+    ]);
+
+    expect(result).toEqual({
+      organic: expect.objectContaining({
+        category: "organic",
+        lastDate: expect.any(String),
+        lastCount: expect.any(Number),
+        lastTotal: expect.any(Number),
+        lastPercentage: expect.any(Number),
+        previousDate: expect.any(String),
+        previousCount: expect.any(Number),
+        previousTotal: expect.any(Number),
+        previousPercentage: expect.any(Number),
+        percentagePointDifference: expect.any(Number),
+      }),
+      mixed: expect.objectContaining({
+        category: "mixed",
+        lastDate: expect.any(String),
+        lastCount: expect.any(Number),
+        lastTotal: expect.any(Number),
+        lastPercentage: expect.any(Number),
+        previousDate: expect.any(String),
+        previousCount: expect.any(Number),
+        previousTotal: expect.any(Number),
+        previousPercentage: expect.any(Number),
+        percentagePointDifference: expect.any(Number),
+      }),
+      automation: expect.objectContaining({
+        category: "automation",
+        previousDate: expect.any(String),
+        previousCount: expect.any(Number),
+        previousTotal: expect.any(Number),
+        previousPercentage: expect.any(Number),
+        lastDate: expect.any(String),
+        lastCount: expect.any(Number),
+        lastTotal: expect.any(Number),
+        lastPercentage: expect.any(Number),
+        percentagePointDifference: expect.any(Number),
+      }),
+    });
+  });
+
+  it("returns null previous values when there is only one date", () => {
+    const result = getCategoryDeltas([
+      createEcosystemHealthItem(lastDate, 90),
+      createEcosystemHealthItem(lastDate, 50),
+      createEcosystemHealthItem(lastDate, 10),
+    ]);
+
+    expect(result).toEqual({
+      organic: expect.objectContaining({
+        category: "organic",
+        lastDate: expect.any(String),
+        lastCount: expect.any(Number),
+        lastTotal: expect.any(Number),
+        lastPercentage: expect.any(Number),
+        previousDate: undefined,
+        previousCount: null,
+        previousTotal: null,
+        previousPercentage: null,
+        percentagePointDifference: null,
+      }),
+      mixed: expect.objectContaining({
+        category: "mixed",
+        lastDate: expect.any(String),
+        lastCount: expect.any(Number),
+        lastTotal: expect.any(Number),
+        lastPercentage: expect.any(Number),
+        previousDate: undefined,
+        previousCount: null,
+        previousTotal: null,
+        previousPercentage: null,
+        percentagePointDifference: null,
+      }),
+      automation: expect.objectContaining({
+        category: "automation",
+        lastDate: expect.any(String),
+        lastCount: expect.any(Number),
+        lastTotal: expect.any(Number),
+        lastPercentage: expect.any(Number),
+        previousDate: undefined,
+        previousCount: null,
+        previousTotal: null,
+        previousPercentage: null,
+        percentagePointDifference: null,
+      }),
+    });
+  });
+
+  it("returns null values when the source is empty", () => {
+    const result = getCategoryDeltas([]);
+
+    expect(result).toEqual({
+      organic: expect.objectContaining({
+        category: "organic",
+        lastDate: undefined,
+        lastCount: null,
+        lastTotal: null,
+        lastPercentage: null,
+        previousDate: undefined,
+        previousCount: null,
+        previousTotal: null,
+        previousPercentage: null,
+        percentagePointDifference: null,
+      }),
+      mixed: expect.objectContaining({
+        category: "mixed",
+        lastDate: undefined,
+        lastCount: null,
+        lastTotal: null,
+        lastPercentage: null,
+        previousDate: undefined,
+        previousCount: null,
+        previousTotal: null,
+        previousPercentage: null,
+        percentagePointDifference: null,
+      }),
+      automation: expect.objectContaining({
+        category: "automation",
+        lastDate: undefined,
+        lastCount: null,
+        lastTotal: null,
+        lastPercentage: null,
+        previousDate: undefined,
+        previousCount: null,
+        previousTotal: null,
+        previousPercentage: null,
+        percentagePointDifference: null,
+      }),
+    });
+  });
+
+  it("calculates accurate category percentages and point differences", () => {
+    const result = getCategoryDeltas([
+      createEcosystemHealthItem(lastDate, 90),
+      createEcosystemHealthItem(lastDate, 50),
+      createEcosystemHealthItem(lastDate, 50),
+      createEcosystemHealthItem(lastDate, 10),
+
+      createEcosystemHealthItem(previousDate, 90),
+      createEcosystemHealthItem(previousDate, 90),
+      createEcosystemHealthItem(previousDate, 50),
+      createEcosystemHealthItem(previousDate, 10),
+    ]);
+
+    expect(result.organic.previousPercentage).toBe(50);
+    expect(result.organic.lastPercentage).toBe(25);
+    expect(result.organic.percentagePointDifference).toBe(-25);
+
+    expect(result.mixed.previousPercentage).toBe(25);
+    expect(result.mixed.lastPercentage).toBe(50);
+    expect(result.mixed.percentagePointDifference).toBe(25);
+
+    expect(result.automation.previousPercentage).toBe(25);
+    expect(result.automation.lastPercentage).toBe(25);
+    expect(result.automation.percentagePointDifference).toBe(0);
   });
 });


### PR DESCRIPTION
This improves the discord stats with daily percentages, deltas vs previous day (1 decimal), and overall trend; for categories and automation PR closure rate.

A bunch of utils are added to that effect, that we could eventually use to surface the info on the health page (?).

Example output:

```json
{
 "content": "Daily Dose of Clankers\n\n🟢 Organic 60.9% ↓ -3.5 pts (↓ -16% overall)\n🟡 Mixed 13.46% ↑ +3.5 pts (↓ -14% overall)\n🔴 Automation 25.64% → 0 pts (↑ +52% overall)\n\n⚫ Automation PR closure rate 52% ↓ -19 pts (47% overall)"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR closure rate tracking with day-over-day trend analysis
  * Enhanced Discord notifications with improved metric formatting and trend indicators
  * Added per-category percentage delta tracking

* **Tests**
  * Added comprehensive test coverage for closure rate and category tracking functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->