### PR TITLE
fix: improve discord notification layout

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -589,4 +589,10 @@ I figure out why it is not so in this project, as I don't replicate in vue-data-
 :deep(.vdui-shape-circle) {
   transition: 300ms all ease-in-out !important;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  :deep(.vdui-shape-circle) {
+    transition: none !important;
+  }
+}
 </style>

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -583,4 +583,10 @@ function getZapIconPath({ x, y }: { x: number; y: number }) {
   stroke-width: 4;
   paint-order: stroke;
 }
+
+/** For some reason when filtering the legend, datapoint circles are not transitioned, this is until
+I figure out why it is not so in this project, as I don't replicate in vue-data-ui playgrounds */
+:deep(.vdui-shape-circle) {
+  transition: 300ms all ease-in-out !important;
+}
 </style>

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -549,6 +549,7 @@ function getZapIconPath({ x, y }: { x: number; y: number }) {
             :key="`${alerts.name}-${plot.absoluteIndex}`"
           >
             <path
+              class="zap-icon"
               v-show="plot.isAlert"
               :d="
                 getZapIconPath({
@@ -584,6 +585,10 @@ function getZapIconPath({ x, y }: { x: number; y: number }) {
   paint-order: stroke;
 }
 
+.zap-icon {
+  transition: all 300ms ease-in-out !important;
+}
+
 /** For some reason when filtering the legend, datapoint circles are not transitioned, this is until
 I figure out why it is not so in this project, as I don't replicate in vue-data-ui playgrounds */
 :deep(.vdui-shape-circle) {
@@ -591,7 +596,8 @@ I figure out why it is not so in this project, as I don't replicate in vue-data-
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :deep(.vdui-shape-circle) {
+  :deep(.vdui-shape-circle),
+  .zap-icon {
     transition: none !important;
   }
 }

--- a/app/components/Report/WeeklyClassification.vue
+++ b/app/components/Report/WeeklyClassification.vue
@@ -9,6 +9,7 @@ import {
   CLASSIFICATION_CATEGORIES,
   getClassificationByDateChunks,
 } from "~~/shared/utils/count-classification-by-date";
+import { formatDateRange } from "~~/shared/utils/dates";
 
 import("vue-data-ui/style.css");
 
@@ -35,36 +36,6 @@ const palette = computed(() => ({
   automation: colors.value.red,
 }));
 
-function formatDateRange({
-  startDate,
-  endDate,
-}: {
-  startDate: string | undefined;
-  endDate: string | undefined;
-}): string {
-  if (!startDate || !endDate) {
-    return "";
-  }
-
-  const start = new Date(startDate);
-  const end = new Date(endDate);
-
-  const startLabel = new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    timeZone: "UTC",
-  }).format(start);
-
-  const endLabel = new Intl.DateTimeFormat("en-GB", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-    timeZone: "UTC",
-  }).format(end);
-
-  return `${startLabel} - ${endLabel}`;
-}
-
 const stackbarDataset = computed<VueUiStackbarDatasetItem[]>(() => {
   return CLASSIFICATION_CATEGORIES.map((classificationKey) => {
     return {
@@ -88,6 +59,9 @@ const timeLabels = computed<string[]>(() => {
     return `Week ${weekNumber} (${formatDateRange({
       startDate: week.startDate,
       endDate: week.endDate,
+      startYear: false,
+      endYear: true,
+      locale: "en-GB",
     })})`;
   });
 });

--- a/scripts/notify-discord.ts
+++ b/scripts/notify-discord.ts
@@ -11,11 +11,10 @@ import {
   getCategoryDeltas,
 } from "../shared/utils/count-classification-by-date";
 import { unpack } from "../shared/utils/compactor";
+import { formatDateRange } from "../shared/utils/dates";
 
 async function main() {
-  const results = unpack(
-    readFileSync("data/scan-results.txt", "utf-8"),
-  );
+  const results = unpack(readFileSync("data/scan-results.txt", "utf-8"));
 
   if (!results?.length) {
     console.log("No data returned from API");
@@ -53,7 +52,7 @@ async function main() {
 
   function trendLabel(trendValue: number): string {
     const arrow = trendValue > 0 ? "↑" : trendValue < 0 ? "↓" : "→";
-    return `${arrow} ${formatTrend(trendValue)} overall`;
+    return `${arrow} ${formatTrend(trendValue)}`;
   }
 
   function statLabel(value: number | null, suffix = ""): string {
@@ -71,11 +70,25 @@ async function main() {
     content: [
       "Daily Dose of Clankers",
       "",
-      `🟢 Organic ${percentageLabel(categoryDeltas.organic.lastPercentage)} ${statLabel(categoryDeltas.organic.percentagePointDifference, " pts")} (${trendLabel(categoryProgression.organic.trend)})`,
-      `🟡 Mixed ${percentageLabel(categoryDeltas.mixed.lastPercentage)} ${statLabel(categoryDeltas.mixed.percentagePointDifference, " pts")} (${trendLabel(categoryProgression.mixed.trend)})`,
-      `🔴 Automation ${percentageLabel(categoryDeltas.automation.lastPercentage)} ${statLabel(categoryDeltas.automation.percentagePointDifference, " pts")} (${trendLabel(categoryProgression.automation.trend)})`,
+      `${formatDateRange({ startDate: dates[0], endDate: dates.at(-1), startYear: true, endYear: true, locale: "en-GB" })}`,
       "",
-      `⚫ Automation PR closure rate ${percentageLabel(closedAutomationPrDelta.lastSnapshot.percentage)} ${statLabel(closedAutomationPrDelta.percentagePointDifference, " pts")} (${percentageLabel(closedAutomationPrPercentage)} overall)`,
+      `🟢 Organic`,
+      `   today: ${percentageLabel(categoryDeltas.organic.lastPercentage)}, ${statLabel(categoryDeltas.organic.percentagePointDifference, " pts")}`,
+      `   overall trend: ${trendLabel(categoryProgression.organic.trend)}`,
+      "",
+      `🟡 Mixed`,
+      `   today: ${percentageLabel(categoryDeltas.mixed.lastPercentage)}, ${statLabel(categoryDeltas.mixed.percentagePointDifference, " pts")}`,
+      `   overall trend: ${trendLabel(categoryProgression.mixed.trend)}`,
+      "",
+      `🔴 Automation`,
+      `   today: ${percentageLabel(categoryDeltas.automation.lastPercentage)}, ${statLabel(categoryDeltas.automation.percentagePointDifference, " pts")}`,
+      `   overall trend: ${trendLabel(categoryProgression.automation.trend)}`,
+      "",
+      "",
+      `⚫ Automation PR closure rate`,
+      `   today: ${percentageLabel(closedAutomationPrDelta.lastSnapshot.percentage)}, ${statLabel(closedAutomationPrDelta.percentagePointDifference, " pts")}`,
+      `   overall: ${percentageLabel(closedAutomationPrPercentage)}`,
+      "",
     ].join("\n"),
   };
 
@@ -84,6 +97,7 @@ async function main() {
   if (!webhook) {
     console.log("Discord webhook URL not found!");
     console.log(JSON.stringify(payload, null, 2));
+    console.log(payload.content);
     return;
   }
 

--- a/shared/utils/dates.ts
+++ b/shared/utils/dates.ts
@@ -1,0 +1,36 @@
+export function formatDateRange({
+  startDate,
+  endDate,
+  startYear = false,
+  endYear = true,
+  locale = "en-GB",
+}: {
+  startDate: string | undefined;
+  endDate: string | undefined;
+  startYear?: boolean;
+  endYear?: boolean;
+  locale?: string;
+}): string {
+  if (!startDate || !endDate) {
+    return "";
+  }
+
+  const start = new Date(startDate);
+  const end = new Date(endDate);
+
+  const startLabel = new Intl.DateTimeFormat(locale, {
+    day: "2-digit",
+    month: "short",
+    timeZone: "UTC",
+    year: startYear ? "numeric" : undefined,
+  }).format(start);
+
+  const endLabel = new Intl.DateTimeFormat(locale, {
+    day: "2-digit",
+    month: "short",
+    year: endYear ? "numeric" : undefined,
+    timeZone: "UTC",
+  }).format(end);
+
+  return `${startLabel} - ${endLabel}`;
+}

--- a/shared/utils/dates.ts
+++ b/shared/utils/dates.ts
@@ -18,6 +18,8 @@ export function formatDateRange({
   const start = new Date(startDate);
   const end = new Date(endDate);
 
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return "";
+
   const startLabel = new Intl.DateTimeFormat(locale, {
     day: "2-digit",
     month: "short",

--- a/test/unit/shared/utils/dates.test.ts
+++ b/test/unit/shared/utils/dates.test.ts
@@ -98,4 +98,21 @@ describe("formatDateRange", () => {
       }),
     ).toBe("");
   });
+
+  it("returns an empty string when the start date is invalid", () => {
+    expect(
+      formatDateRange({
+        startDate: "invalid-date",
+        endDate: "2026-05-29",
+      }),
+    ).toBe("");
+  });
+  +it("returns an empty string when the end date is invalid", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-13-45",
+      }),
+    ).toBe("");
+  });
 });

--- a/test/unit/shared/utils/dates.test.ts
+++ b/test/unit/shared/utils/dates.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { formatDateRange } from "../../../../shared/utils/dates";
+
+describe("formatDateRange", () => {
+  it("formats a date range with YYYY-MM-DD inputs", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-05-29",
+      }),
+    ).toBe("26 May - 29 May 2026");
+  });
+
+  it("formats a date range with ISO date-time inputs", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26T00:00:00.000Z",
+        endDate: "2026-05-29T00:00:00.000Z",
+      }),
+    ).toBe("26 May - 29 May 2026");
+  });
+
+  it("can include the year on the start date", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-05-29",
+        startYear: true,
+      }),
+    ).toBe("26 May 2026 - 29 May 2026");
+  });
+
+  it("can hide the year on the end date", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-05-29",
+        endYear: false,
+      }),
+    ).toBe("26 May - 29 May");
+  });
+
+  it("can include the year on both dates", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-05-29",
+        startYear: true,
+        endYear: true,
+      }),
+    ).toBe("26 May 2026 - 29 May 2026");
+  });
+
+  it("can hide the year on both dates", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-05-29",
+        startYear: false,
+        endYear: false,
+      }),
+    ).toBe("26 May - 29 May");
+  });
+
+  it("uses the provided locale", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: "2026-05-29",
+        locale: "en-US",
+      }),
+    ).toBe("May 26 - May 29, 2026");
+  });
+
+  it("returns an empty string when the start date is missing", () => {
+    expect(
+      formatDateRange({
+        startDate: undefined,
+        endDate: "2026-05-29",
+      }),
+    ).toBe("");
+  });
+
+  it("returns an empty string when the end date is missing", () => {
+    expect(
+      formatDateRange({
+        startDate: "2026-05-26",
+        endDate: undefined,
+      }),
+    ).toBe("");
+  });
+
+  it("returns an empty string when both dates are missing", () => {
+    expect(
+      formatDateRange({
+        startDate: undefined,
+        endDate: undefined,
+      }),
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
This lays out the discord notification in a slightly more comprehensive way:

Result in the terminal (logged when no key is provided):

<img width="245" height="331" alt="image" src="https://github.com/user-attachments/assets/f0557329-09b7-4a08-b76e-1a1def910741" />

Note: perhaps the alignment below the category names will need extra spaces, since discord is not in unicode (?)

Other:
- extract date range function into shared utils + test
- unrelated small css improvements in the health chart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a shared date range formatting utility for consistent date display across the application

* **Improvements**
  * Enhanced chart visualization transitions for smoother interactions when filtering by legend
  * Refined Discord notification message layout with clearer section organization and improved readability

* **Tests**
  * Added comprehensive unit tests for date range formatting functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->