### PR TITLE
feat(github-webhook): add scan mode

### DIFF
--- a/server/api/webhook/github.post.ts
+++ b/server/api/webhook/github.post.ts
@@ -15,12 +15,14 @@ type AutomationListItem = {
   issueUrl: string
 }
 
+type ScanMode = 'full' | 'labels' | 'comment' | 'silent'
+
 type RepoConfig = {
   skipMembers: string[]
   autoClose: boolean
   autoCloseClassifications: IdentityClassification[]
-  agentScanComment: boolean
-  skipCommentOnOrganic: boolean
+  mode: ScanMode
+  skipOnOrganic: boolean
   labels: {
     communityFlagged: string
     mixed: string
@@ -38,8 +40,8 @@ type PartialRepoConfig = {
   skipMembers?: string[]
   autoClose?: boolean
   autoCloseClassifications?: IdentityClassification[]
-  agentScanComment?: boolean
-  skipCommentOnOrganic?: boolean
+  mode?: ScanMode
+  skipOnOrganic?: boolean
   labels?: Partial<RepoConfig['labels']>
   messages?: Partial<RepoConfig['messages']>
 }
@@ -48,8 +50,8 @@ const DEFAULT_CONFIG: RepoConfig = {
   skipMembers: [],
   autoClose: false,
   autoCloseClassifications: ['automation'],
-  agentScanComment: true,
-  skipCommentOnOrganic: false,
+  mode: 'full',
+  skipOnOrganic: false,
   labels: {
     communityFlagged: 'agentscan:community-flagged',
     mixed: 'agentscan:mixed-signals',
@@ -183,11 +185,11 @@ export default defineEventHandler(async (event) => {
 
   const isFlagged = hasCommunityFlag || analysis.classification !== 'organic'
 
-  if (
-    repoConfig.skipCommentOnOrganic &&
-    !hasCommunityFlag &&
-    analysis.classification === 'organic'
-  ) {
+  if (repoConfig.skipOnOrganic && !hasCommunityFlag && analysis.classification === 'organic') {
+    return { ok: true }
+  }
+
+  if (repoConfig.mode === 'silent') {
     return { ok: true }
   }
 
@@ -226,7 +228,7 @@ export default defineEventHandler(async (event) => {
   ].join('\n')
 
   try {
-    if (repoConfig.agentScanComment) {
+    if (repoConfig.mode === 'full' || repoConfig.mode === 'comment') {
       const { data: existingComments } = await octokit.rest.issues.listComments({
         owner,
         repo,
@@ -241,31 +243,33 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    const labelsToAdd: string[] = []
-    if (hasCommunityFlag) {
-      labelsToAdd.push(repoConfig.labels.communityFlagged)
-    } else if (analysis.classification !== 'organic') {
-      const labelMap: Record<Exclude<IdentityClassification, 'organic'>, string> = {
-        mixed: repoConfig.labels.mixed,
-        automation: repoConfig.labels.automation,
+    if (repoConfig.mode === 'full' || repoConfig.mode === 'labels') {
+      const labelsToAdd: string[] = []
+      if (hasCommunityFlag) {
+        labelsToAdd.push(repoConfig.labels.communityFlagged)
+      } else if (analysis.classification !== 'organic') {
+        const labelMap: Record<Exclude<IdentityClassification, 'organic'>, string> = {
+          mixed: repoConfig.labels.mixed,
+          automation: repoConfig.labels.automation,
+        }
+        labelsToAdd.push(labelMap[analysis.classification])
       }
-      labelsToAdd.push(labelMap[analysis.classification])
-    }
 
-    if (labelsToAdd.length > 0) {
-      await Promise.all(
-        labelsToAdd.map((name) =>
-          octokit.rest.issues.createLabel({ owner, repo, name, color: 'ededed' }).catch(() => {
-            // label already exists or no create permission — continue to addLabels
-          }),
-        ),
-      )
-      await octokit.rest.issues.addLabels({
-        owner,
-        repo,
-        issue_number: prNumber,
-        labels: labelsToAdd,
-      })
+      if (labelsToAdd.length > 0) {
+        await Promise.all(
+          labelsToAdd.map((name) =>
+            octokit.rest.issues.createLabel({ owner, repo, name, color: 'ededed' }).catch(() => {
+              // label already exists or no create permission — continue to addLabels
+            }),
+          ),
+        )
+        await octokit.rest.issues.addLabels({
+          owner,
+          repo,
+          issue_number: prNumber,
+          labels: labelsToAdd,
+        })
+      }
     }
   } catch (err: unknown) {
     if (err instanceof Error && !err.message.includes('Resource not accessible')) {

--- a/server/api/webhook/github.post.ts
+++ b/server/api/webhook/github.post.ts
@@ -214,7 +214,7 @@ export default defineEventHandler(async (event) => {
     description = repoConfig.messages[analysis.classification]
   }
 
-  const MARKER = '<!-- agentscan-bot -->'
+  const MARKER = '<!-- agentscanapp-bot -->'
 
   const body = [
     MARKER,

--- a/shared/daily-scan.ts
+++ b/shared/daily-scan.ts
@@ -35,6 +35,7 @@ export const libraries = [
 ] as const
 
 export const cicdBots = [
+  'agentscanapp',
   'copilot',
   'dependabot',
   'renovate',

--- a/test/unit/server/api/webhook/github.post.test.ts
+++ b/test/unit/server/api/webhook/github.post.test.ts
@@ -1,0 +1,583 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { IdentifyResult } from '@unveil/identity'
+import { getClassificationDetails, identify } from '@unveil/identity'
+import { parse as parseYaml } from 'yaml'
+import handler from '../../../../../server/api/webhook/github.post'
+
+// vi.hoisted runs before all module imports — used to stub Nuxt auto-imports
+// and to create shared mock objects referenced in vi.mock() factories below.
+const {
+  mockWebhooks,
+  mockInstallationOctokit,
+  mockAppOctokit,
+  mockApp,
+  readRawBodyMock,
+  useRuntimeConfigMock,
+  getHeaderMock,
+} = vi.hoisted(() => {
+  const mockWebhooks = { verify: vi.fn() }
+
+  const mockInstallationOctokit = {
+    rest: {
+      repos: { getContent: vi.fn() },
+      users: { getByUsername: vi.fn() },
+      activity: { listPublicEventsForUser: vi.fn() },
+      issues: {
+        listComments: vi.fn(),
+        createComment: vi.fn(),
+        updateComment: vi.fn(),
+        addLabels: vi.fn(),
+        createLabel: vi.fn(),
+        update: vi.fn(),
+      },
+    },
+  }
+
+  const mockAppOctokit = {
+    rest: { repos: { getContent: vi.fn() } },
+  }
+
+  const mockApp = {
+    getInstallationOctokit: vi.fn(),
+    octokit: mockAppOctokit,
+  }
+
+  const readRawBodyMock = vi.fn()
+  const useRuntimeConfigMock = vi.fn()
+  const getHeaderMock = vi.fn()
+
+  vi.stubGlobal('defineEventHandler', (fn: () => void) => fn)
+  vi.stubGlobal('readRawBody', readRawBodyMock)
+  vi.stubGlobal('useRuntimeConfig', useRuntimeConfigMock)
+  vi.stubGlobal('getHeader', getHeaderMock)
+  vi.stubGlobal(
+    'createError',
+    ({ statusCode, message }: { statusCode: number; message: string }) => {
+      const err = new Error(message) as Error & { statusCode: number }
+      err.statusCode = statusCode
+      return err
+    },
+  )
+
+  return {
+    mockWebhooks,
+    mockInstallationOctokit,
+    mockAppOctokit,
+    mockApp,
+    readRawBodyMock,
+    useRuntimeConfigMock,
+    getHeaderMock,
+  }
+})
+
+vi.mock('octokit', () => ({
+  App: vi.fn().mockImplementation(function () {
+    return mockApp
+  }),
+}))
+vi.mock('@octokit/webhooks', () => ({
+  Webhooks: vi.fn().mockImplementation(function () {
+    return mockWebhooks
+  }),
+}))
+vi.mock('@unveil/identity')
+vi.mock('yaml', () => ({ parse: vi.fn() }))
+
+// --- Shared fixtures ---
+
+const RUNTIME_CONFIG = {
+  githubWebhookSecret: 'test-secret',
+  githubAppId: 'test-app-id',
+  githubAppPrivateKey: Buffer.from('test-private-key').toString('base64'),
+}
+
+const BASE_PAYLOAD = {
+  action: 'opened',
+  pull_request: { number: 123, user: { login: 'test-user' } },
+  installation: { id: 42 },
+  repository: { owner: { login: 'test-owner' }, name: 'test-repo' },
+}
+
+const MOCK_ANALYSIS: IdentifyResult = {
+  classification: 'organic',
+  score: 20,
+  flags: [
+    {
+      label: 'Test Flag',
+      points: 10,
+      detail: 'Test detail',
+      data: [],
+      events: [],
+    },
+  ],
+  isBountyHunter: false,
+  profile: { age: 365, repos: 0 },
+}
+
+// The event object itself is irrelevant — handler accesses it only via mocked globals.
+const MOCK_EVENT = {}
+
+// --- Helpers ---
+
+function setupEvent(
+  payloadOverrides: Record<string, unknown> = {},
+  configOverrides: Record<string, unknown> = {},
+) {
+  const payload = { ...BASE_PAYLOAD, ...payloadOverrides }
+  readRawBodyMock.mockResolvedValue(JSON.stringify(payload))
+  getHeaderMock.mockReturnValue('sha256=valid-signature')
+  useRuntimeConfigMock.mockReturnValue({ ...RUNTIME_CONFIG, ...configOverrides })
+}
+
+function mockRepoConfig(config: Record<string, unknown>) {
+  mockInstallationOctokit.rest.repos.getContent.mockResolvedValueOnce({
+    data: { content: Buffer.from('dummy yaml content').toString('base64') },
+  })
+  vi.mocked(parseYaml).mockReturnValueOnce(config)
+}
+
+function mockVerifiedList(usernames: string[]) {
+  const entries = usernames.map((username) => ({
+    username,
+    reason: 'Verified automation',
+    createdAt: '2024-01-01',
+    issueUrl: 'https://example.com',
+  }))
+  mockAppOctokit.rest.repos.getContent.mockResolvedValueOnce({
+    data: { content: Buffer.from(JSON.stringify(entries)).toString('base64') },
+  })
+}
+
+// --- Tests ---
+
+describe('GitHub Webhook Handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Default: valid signature, full PR payload, no agentscan.yml, no verified list
+    mockWebhooks.verify.mockResolvedValue(true)
+    mockApp.getInstallationOctokit.mockResolvedValue(mockInstallationOctokit)
+    mockInstallationOctokit.rest.repos.getContent.mockRejectedValue(new Error('Not Found'))
+    mockInstallationOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { public_repos: 10, created_at: '2020-01-01T00:00:00Z' },
+    })
+    mockInstallationOctokit.rest.activity.listPublicEventsForUser.mockResolvedValue({ data: [] })
+    mockInstallationOctokit.rest.issues.listComments.mockResolvedValue({ data: [] })
+    mockInstallationOctokit.rest.issues.createComment.mockResolvedValue({})
+    mockInstallationOctokit.rest.issues.updateComment.mockResolvedValue({})
+    mockInstallationOctokit.rest.issues.addLabels.mockResolvedValue({})
+    mockInstallationOctokit.rest.issues.createLabel.mockResolvedValue({})
+    mockInstallationOctokit.rest.issues.update.mockResolvedValue({})
+    mockAppOctokit.rest.repos.getContent.mockRejectedValue(new Error('Not Found'))
+
+    vi.mocked(identify).mockReturnValue(MOCK_ANALYSIS)
+    vi.mocked(getClassificationDetails).mockReturnValue({
+      label: 'Organic Account',
+      description: 'This account appears to be organic.',
+    })
+
+    setupEvent()
+  })
+
+  describe('Signature Verification', () => {
+    it('returns 400 when the body is empty', async () => {
+      readRawBodyMock.mockResolvedValue(null)
+
+      await expect(handler(MOCK_EVENT)).rejects.toMatchObject({ statusCode: 400 })
+    })
+
+    it('returns 503 when the webhook secret is not configured', async () => {
+      useRuntimeConfigMock.mockReturnValue({ ...RUNTIME_CONFIG, githubWebhookSecret: '' })
+
+      await expect(handler(MOCK_EVENT)).rejects.toMatchObject({ statusCode: 503 })
+    })
+
+    it('returns 401 when the x-hub-signature-256 header is missing', async () => {
+      getHeaderMock.mockReturnValue(null)
+
+      await expect(handler(MOCK_EVENT)).rejects.toMatchObject({ statusCode: 401 })
+    })
+
+    it('returns 401 when the signature is invalid', async () => {
+      mockWebhooks.verify.mockResolvedValue(false)
+
+      await expect(handler(MOCK_EVENT)).rejects.toMatchObject({ statusCode: 401 })
+    })
+  })
+
+  describe('Early Returns', () => {
+    it('returns { ok: true } for non-opened/reopened actions', async () => {
+      setupEvent({ action: 'closed' })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(identify).not.toHaveBeenCalled()
+    })
+
+    it('returns { ok: true } when pull_request is absent from payload', async () => {
+      setupEvent({ pull_request: undefined })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(identify).not.toHaveBeenCalled()
+    })
+
+    it('returns { ok: true } when installation is absent from payload', async () => {
+      setupEvent({ installation: undefined })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(identify).not.toHaveBeenCalled()
+    })
+
+    it('returns 503 when GitHub App credentials are not configured', async () => {
+      useRuntimeConfigMock.mockReturnValue({
+        ...RUNTIME_CONFIG,
+        githubAppId: '',
+        githubAppPrivateKey: '',
+      })
+
+      await expect(handler(MOCK_EVENT)).rejects.toMatchObject({ statusCode: 503 })
+    })
+
+    it('returns { ok: true } for reopened PRs', async () => {
+      setupEvent({ action: 'reopened' })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true, flagged: false, classification: 'organic' })
+    })
+  })
+
+  describe('Normal Flow', () => {
+    it('fetches 3 pages of public events', async () => {
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.activity.listPublicEventsForUser).toHaveBeenCalledTimes(3)
+      expect(mockInstallationOctokit.rest.activity.listPublicEventsForUser).toHaveBeenNthCalledWith(
+        1,
+        {
+          username: 'test-user',
+          per_page: 100,
+          page: 1,
+        },
+      )
+      expect(mockInstallationOctokit.rest.activity.listPublicEventsForUser).toHaveBeenNthCalledWith(
+        3,
+        {
+          username: 'test-user',
+          per_page: 100,
+          page: 3,
+        },
+      )
+    })
+
+    it('calls identify with user data from the GitHub API', async () => {
+      mockInstallationOctokit.rest.users.getByUsername.mockResolvedValue({
+        data: { public_repos: 25, created_at: '2019-06-15T00:00:00Z' },
+      })
+
+      await handler(MOCK_EVENT)
+
+      expect(identify).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountName: 'test-user',
+          reposCount: 25,
+          createdAt: '2019-06-15T00:00:00Z',
+        }),
+      )
+    })
+
+    it('returns classification and flagged status', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toMatchObject({ ok: true, flagged: true, classification: 'automation' })
+    })
+
+    it('returns flagged: false for organic accounts', async () => {
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toMatchObject({ ok: true, flagged: false, classification: 'organic' })
+    })
+  })
+
+  describe('Skip Members (via repo config)', () => {
+    it('returns { ok: true } without scanning when username is in skipMembers', async () => {
+      mockRepoConfig({ skipMembers: ['test-user', 'other-user'] })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(identify).not.toHaveBeenCalled()
+    })
+
+    it('proceeds with scan when username is not in skipMembers', async () => {
+      mockRepoConfig({ skipMembers: ['other-user'] })
+
+      await handler(MOCK_EVENT)
+
+      expect(identify).toHaveBeenCalled()
+    })
+  })
+
+  describe('Scan Mode: silent', () => {
+    it('returns { ok: true } without posting a comment or adding labels', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({ mode: 'silent' })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(mockInstallationOctokit.rest.issues.createComment).not.toHaveBeenCalled()
+      expect(mockInstallationOctokit.rest.issues.addLabels).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Scan Mode: labels', () => {
+    it('adds labels but does not post a comment', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({ mode: 'labels' })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).toHaveBeenCalled()
+      expect(mockInstallationOctokit.rest.issues.createComment).not.toHaveBeenCalled()
+    })
+
+    it('does not add labels for organic accounts in labels mode', async () => {
+      mockRepoConfig({ mode: 'labels' })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Scan Mode: comment', () => {
+    it('posts a comment but does not add labels', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({ mode: 'comment' })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.createComment).toHaveBeenCalled()
+      expect(mockInstallationOctokit.rest.issues.addLabels).not.toHaveBeenCalled()
+    })
+
+    it('updates an existing agentscan comment instead of creating a new one', async () => {
+      mockRepoConfig({ mode: 'comment' })
+      mockInstallationOctokit.rest.issues.listComments.mockResolvedValue({
+        data: [{ id: 999, body: '<!-- agentscanapp-bot -->\n### ✅ Organic Account' }],
+      })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.updateComment).toHaveBeenCalledWith(
+        expect.objectContaining({ comment_id: 999 }),
+      )
+      expect(mockInstallationOctokit.rest.issues.createComment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Scan Mode: full (default)', () => {
+    it('posts a comment and adds labels when classification is not organic', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      vi.mocked(getClassificationDetails).mockReturnValue({
+        label: 'Automated Account',
+        description: 'This account appears to be automated.',
+      })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.createComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          issue_number: 123,
+        }),
+      )
+      expect(mockInstallationOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'test-owner',
+          repo: 'test-repo',
+          issue_number: 123,
+          labels: ['agentscan:automated-account'],
+        }),
+      )
+    })
+
+    it('posts a comment but no labels for organic accounts', async () => {
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.createComment).toHaveBeenCalled()
+      expect(mockInstallationOctokit.rest.issues.addLabels).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('Label Assignment', () => {
+    it('does not add labels for organic classification', async () => {
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).not.toHaveBeenCalled()
+    })
+
+    it('adds mixed-signals label for mixed classification', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'mixed' })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['agentscan:mixed-signals'] }),
+      )
+    })
+
+    it('adds automated-account label for automation classification', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['agentscan:automated-account'] }),
+      )
+    })
+
+    it('adds community-flagged label for accounts in the verified list', async () => {
+      mockVerifiedList(['test-user'])
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['agentscan:community-flagged'] }),
+      )
+    })
+
+    it('uses custom labels from repo config', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({
+        labels: {
+          automation: 'blocked:bot-account',
+          mixed: 'review:mixed-signals',
+          communityFlagged: 'security:flagged',
+        },
+      })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ['blocked:bot-account'] }),
+      )
+    })
+  })
+
+  describe('skipOnOrganic', () => {
+    it('returns { ok: true } without comment or labels for organic accounts when enabled', async () => {
+      mockRepoConfig({ skipOnOrganic: true })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(mockInstallationOctokit.rest.issues.createComment).not.toHaveBeenCalled()
+    })
+
+    it('still posts comment for community-flagged accounts even when skipOnOrganic is true', async () => {
+      mockRepoConfig({ skipOnOrganic: true })
+      mockVerifiedList(['test-user'])
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.createComment).toHaveBeenCalled()
+    })
+
+    it('still posts comment for non-organic accounts when skipOnOrganic is true', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({ skipOnOrganic: true })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.createComment).toHaveBeenCalled()
+    })
+  })
+
+  describe('Auto-Close', () => {
+    it('does not close the PR when autoClose is disabled (default)', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.update).not.toHaveBeenCalled()
+    })
+
+    it('closes the PR when autoClose is enabled and classification matches', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({ autoClose: true, autoCloseClassifications: ['automation'] })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.update).toHaveBeenCalledWith({
+        owner: 'test-owner',
+        repo: 'test-repo',
+        issue_number: 123,
+        state: 'closed',
+        state_reason: 'not_planned',
+      })
+    })
+
+    it('does not close the PR when classification is not in autoCloseClassifications', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'mixed' })
+      mockRepoConfig({ autoClose: true, autoCloseClassifications: ['automation'] })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.update).not.toHaveBeenCalled()
+    })
+
+    it('closes community-flagged PRs when autoClose is enabled', async () => {
+      mockRepoConfig({ autoClose: true, autoCloseClassifications: ['automation'] })
+      mockVerifiedList(['test-user'])
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.update).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'closed', state_reason: 'not_planned' }),
+      )
+    })
+
+    it('closes the PR when multiple classifications are in the autoClose list', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'mixed' })
+      mockRepoConfig({ autoClose: true, autoCloseClassifications: ['automation', 'mixed'] })
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.issues.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('Custom Messages (via repo config)', () => {
+    it('uses the custom automation message in the posted comment', async () => {
+      vi.mocked(identify).mockReturnValue({ ...MOCK_ANALYSIS, classification: 'automation' })
+      mockRepoConfig({
+        messages: { automation: 'This PR was opened by a bot. Please review carefully.' },
+      })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall = mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).toContain('This PR was opened by a bot. Please review carefully.')
+    })
+
+    it('uses the custom communityFlagged message for flagged accounts', async () => {
+      mockVerifiedList(['test-user'])
+      mockRepoConfig({ messages: { communityFlagged: 'Flagged by our community watchlist.' } })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall = mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).toContain('Flagged by our community watchlist.')
+    })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more granular scan modes so repositories can choose between full scans, labels only, comments only, or silent mode.
  * Improved support for identifying and handling additional bot activity during daily scans.

* **Bug Fixes**
  * Updated comment handling to better recognize and refresh previous bot comments.
  * Adjusted organic-account handling to avoid unnecessary comments or labels when skipping is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->