### PR TITLE
fix: set hourly thresholds to display ⚡

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -59,11 +59,13 @@ const eventConfig = computed(() => {
 
   const color = palette[classification]
 
+  const hourlyThresholdRatio = computed(() => (usesHourlyGranularity.value ? 3 : 1))
+
   return {
     ForkEvent: {
       name: 'Forks',
       color: color.fork,
-      threshold: identityConfig.FORKS_EXTREME,
+      threshold: Math.round(identityConfig.FORKS_EXTREME / hourlyThresholdRatio.value),
       visible: selectedLegendItems.value.includes('Forks'),
       labelOffsetY: 40,
     },
@@ -77,7 +79,7 @@ const eventConfig = computed(() => {
     PullRequestEvent: {
       name: 'Pull requests',
       color: color.pr,
-      threshold: identityConfig.PRS_TODAY_EXTREME,
+      threshold: Math.round(identityConfig.PRS_TODAY_EXTREME / hourlyThresholdRatio.value),
       visible: selectedLegendItems.value.includes('Pull requests'),
       labelOffsetY: 6,
     },


### PR DESCRIPTION
Resolves #195

Daily thresholds for forks and PRs are divided by 3 when the granularity is hourly, which shows the ⚡ now when:

- hourly fork is >= 3
- hourly PRs is >= 5

[orbisai0security](http://localhost:3000/user/orbisai0security) is currently showing hours on the chart, and is a good test for a clank profile.
Could not put my hands on an organic profile with hourly granularity to test.