### PR TITLE
feat(app): add trusted-author-associations

### DIFF
--- a/schemas/agentscan.json
+++ b/schemas/agentscan.json
@@ -36,6 +36,22 @@
       },
       "examples": [["dependabot[bot]", "renovate[bot]"]]
     },
+    "trusted-author-associations": {
+      "description": "Author associations to exclude from scanning (e.g. trusted maintainers opening their own PRs/issues).",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "COLLABORATOR",
+          "CONTRIBUTOR",
+          "FIRST_TIMER",
+          "FIRST_TIME_CONTRIBUTOR",
+          "MEMBER",
+          "OWNER"
+        ]
+      },
+      "examples": [["OWNER", "MEMBER", "COLLABORATOR"]]
+    },
     "silent-on-organic": {
       "description": "Skip posting a comment when the analysis result is 'organic'.",
       "type": "boolean",

--- a/schemas/agentscan.json
+++ b/schemas/agentscan.json
@@ -42,15 +42,15 @@
       "items": {
         "type": "string",
         "enum": [
-          "COLLABORATOR",
-          "CONTRIBUTOR",
-          "FIRST_TIMER",
-          "FIRST_TIME_CONTRIBUTOR",
-          "MEMBER",
-          "OWNER"
+          "collaborator",
+          "contributor",
+          "first_timer",
+          "first_time_contributor",
+          "member",
+          "owner"
         ]
       },
-      "examples": [["OWNER", "MEMBER", "COLLABORATOR"]]
+      "examples": [["owner", "member", "collaborator"]]
     },
     "silent-on-organic": {
       "description": "Skip posting a comment when the analysis result is 'organic'.",

--- a/server/api/webhook/github/_config.ts
+++ b/server/api/webhook/github/_config.ts
@@ -4,12 +4,12 @@ import { parse as parseYaml } from 'yaml'
 export type ScanMode = 'full' | 'labels' | 'comment' | 'silent'
 
 export type AuthorAssociation =
-  | 'COLLABORATOR'
-  | 'CONTRIBUTOR'
-  | 'FIRST_TIMER'
-  | 'FIRST_TIME_CONTRIBUTOR'
-  | 'MEMBER'
-  | 'OWNER'
+  | 'collaborator'
+  | 'contributor'
+  | 'first_timer'
+  | 'first_time_contributor'
+  | 'member'
+  | 'owner'
 
 export const SUPPORTED_CONFIG_VERSION = 1
 

--- a/server/api/webhook/github/_config.ts
+++ b/server/api/webhook/github/_config.ts
@@ -3,11 +3,20 @@ import { parse as parseYaml } from 'yaml'
 
 export type ScanMode = 'full' | 'labels' | 'comment' | 'silent'
 
+export type AuthorAssociation =
+  | 'COLLABORATOR'
+  | 'CONTRIBUTOR'
+  | 'FIRST_TIMER'
+  | 'FIRST_TIME_CONTRIBUTOR'
+  | 'MEMBER'
+  | 'OWNER'
+
 export const SUPPORTED_CONFIG_VERSION = 1
 
 export type RepoConfig = {
   version: number
   'allowed-users': string[]
+  'trusted-author-associations': AuthorAssociation[]
   'auto-close': boolean
   'auto-close-classifications': IdentityClassification[]
   mode: ScanMode
@@ -32,6 +41,7 @@ export type RepoConfig = {
 export const DEFAULT_CONFIG: RepoConfig = {
   version: SUPPORTED_CONFIG_VERSION,
   'allowed-users': [],
+  'trusted-author-associations': [],
   'auto-close': false,
   'auto-close-classifications': ['automation'],
   mode: 'full',

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -69,9 +69,12 @@ export default defineEventHandler(async (event) => {
     payload.pull_request?.number ?? payload.issue?.number
   const username: string | undefined =
     payload.pull_request?.user?.login ?? payload.issue?.user?.login
-  const authorAssociation: AuthorAssociation | undefined =
+  const rawAuthorAssociation: string | undefined =
     payload.pull_request?.author_association ??
     payload.issue?.author_association
+  const authorAssociation = rawAuthorAssociation?.toLowerCase() as
+    | AuthorAssociation
+    | undefined
 
   if (!targetNumber || !username) {
     return { ok: true }

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -7,7 +7,12 @@ import {
   type IdentityClassification,
 } from '@unveil/identity'
 import { isKnownBot } from '~~/shared/cicd-known-bots'
-import { DEFAULT_CONFIG, parseRepoConfig, type RepoConfig } from './_config'
+import {
+  DEFAULT_CONFIG,
+  parseRepoConfig,
+  type AuthorAssociation,
+  type RepoConfig,
+} from './_config'
 
 type AutomationListItem = {
   username: string
@@ -64,6 +69,9 @@ export default defineEventHandler(async (event) => {
     payload.pull_request?.number ?? payload.issue?.number
   const username: string | undefined =
     payload.pull_request?.user?.login ?? payload.issue?.user?.login
+  const authorAssociation: AuthorAssociation | undefined =
+    payload.pull_request?.author_association ??
+    payload.issue?.author_association
 
   if (!targetNumber || !username) {
     return { ok: true }
@@ -113,7 +121,12 @@ export default defineEventHandler(async (event) => {
     return { ok: true }
   }
 
-  if (repoConfig['allowed-users'].includes(username) || isKnownBot(username)) {
+  if (
+    repoConfig['allowed-users'].includes(username) ||
+    isKnownBot(username) ||
+    (authorAssociation &&
+      repoConfig['trusted-author-associations'].includes(authorAssociation))
+  ) {
     return { ok: true }
   }
 

--- a/test/unit/server/api/webhook/github.post.test.ts
+++ b/test/unit/server/api/webhook/github.post.test.ts
@@ -398,6 +398,53 @@ describe('GitHub Webhook Handler', () => {
     })
   })
 
+  describe('Trusted Author Associations (via repo config)', () => {
+    it('returns { ok: true } without scanning when author_association is in trusted-author-associations', async () => {
+      setupEvent({
+        pull_request: {
+          number: 123,
+          user: { login: 'test-user' },
+          author_association: 'OWNER',
+        },
+      })
+      mockRepoConfig({ 'trusted-author-associations': ['OWNER', 'MEMBER'] })
+
+      const result = await handler(MOCK_EVENT)
+
+      expect(result).toEqual({ ok: true })
+      expect(identify).not.toHaveBeenCalled()
+    })
+
+    it('proceeds with scan when author_association is not in trusted-author-associations', async () => {
+      setupEvent({
+        pull_request: {
+          number: 123,
+          user: { login: 'test-user' },
+          author_association: 'CONTRIBUTOR',
+        },
+      })
+      mockRepoConfig({ 'trusted-author-associations': ['OWNER', 'MEMBER'] })
+
+      await handler(MOCK_EVENT)
+
+      expect(identify).toHaveBeenCalled()
+    })
+
+    it('proceeds with scan when trusted-author-associations is not configured', async () => {
+      setupEvent({
+        pull_request: {
+          number: 123,
+          user: { login: 'test-user' },
+          author_association: 'OWNER',
+        },
+      })
+
+      await handler(MOCK_EVENT)
+
+      expect(identify).toHaveBeenCalled()
+    })
+  })
+
   describe('Scan Mode: silent', () => {
     it('returns { ok: true } without posting a comment or adding labels', async () => {
       vi.mocked(identify).mockReturnValue({

--- a/test/unit/server/api/webhook/github.post.test.ts
+++ b/test/unit/server/api/webhook/github.post.test.ts
@@ -407,7 +407,7 @@ describe('GitHub Webhook Handler', () => {
           author_association: 'OWNER',
         },
       })
-      mockRepoConfig({ 'trusted-author-associations': ['OWNER', 'MEMBER'] })
+      mockRepoConfig({ 'trusted-author-associations': ['owner', 'member'] })
 
       const result = await handler(MOCK_EVENT)
 
@@ -423,7 +423,7 @@ describe('GitHub Webhook Handler', () => {
           author_association: 'CONTRIBUTOR',
         },
       })
-      mockRepoConfig({ 'trusted-author-associations': ['OWNER', 'MEMBER'] })
+      mockRepoConfig({ 'trusted-author-associations': ['owner', 'member'] })
 
       await handler(MOCK_EVENT)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to trust specific GitHub author association roles.
  * Webhook processing now skips further scanning for matching trusted associations.

* **Tests**
  * Added coverage for trusted associations, including matching, non-matching, and unset configuration cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->