### PR TITLE
fix: replace sparkline grid with selectable repos and single chart

### DIFF
--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
-import { computed, shallowRef } from 'vue'
+import { computed, shallowRef, watch } from 'vue'
 import {
   VueUiXy,
   type VueUiXyConfig,
-  type VueUiXySeries,
+  type VueUiXyDatasetItem,
+  type VueUiXySvgSlotProps,
   type VueUiXyTooltipSlotProps,
 } from 'vue-data-ui/vue-ui-xy'
+import { useTooltipPosition } from 'vue-data-ui/composables'
 import { identityConfig } from '@unveil/identity'
-import { useTimeoutFn } from '@vueuse/core'
+import { usePreferredDark } from '@vueuse/core'
 
 import('vue-data-ui/style.css')
 
@@ -16,99 +18,359 @@ const dates = computed(() => data.value?.dates)
 
 const rootEl = shallowRef<HTMLElement | null>(null)
 const colors = useColors(rootEl)
+const isDarkMode = usePreferredDark()
 
-const loaded = shallowRef(false)
-
-const { start } = useTimeoutFn(
-  () => {
-    loaded.value = true
-  },
-  250,
-  { immediate: false },
-)
-
-onMounted(start)
-
-const scoreBounds = shallowRef<ScoreBounds>([
+const suspiciousScoreBounds: ScoreBounds = [
   0,
   identityConfig.THRESHOLD_SUSPICIOUS,
-])
+]
+const amberScoreBounds: ScoreBounds = [
+  identityConfig.THRESHOLD_SUSPICIOUS,
+  identityConfig.THRESHOLD_HUMAN,
+]
+const humanScoreBounds: ScoreBounds = [identityConfig.THRESHOLD_HUMAN, 100]
+
+const scoreBounds = shallowRef<ScoreBounds>(suspiciousScoreBounds)
+
+function areScoreBoundsEqual(a: ScoreBounds, b: ScoreBounds) {
+  return a[0] === b[0] && a[1] === b[1]
+}
+
+function isScoreRangeSelected(range: ScoreBounds) {
+  return areScoreBoundsEqual(scoreBounds.value, range)
+}
+
+function setScoreBounds(range: ScoreBounds) {
+  if (areScoreBoundsEqual(scoreBounds.value, range)) {
+    return
+  }
+
+  scoreBounds.value = range
+}
 
 const selectedRangeColor = computed(() => {
-  const [minScore, maxScore] = scoreBounds.value
-  if (minScore === 0 && maxScore === identityConfig.THRESHOLD_SUSPICIOUS) {
+  if (isScoreRangeSelected(suspiciousScoreBounds)) {
     return colors.value.danger
   }
-  if (
-    minScore === identityConfig.THRESHOLD_SUSPICIOUS &&
-    maxScore === identityConfig.THRESHOLD_HUMAN
-  ) {
+  if (isScoreRangeSelected(amberScoreBounds)) {
     return colors.value.amber
   }
   return colors.value.green
 })
 
-const sparklines = computed(() => {
-  return getClosedPrPercentageEvolutionByRepo(
-    data.value?.results ?? [],
+const MAX_SELECTION = 5
+const DEFAULT_SELECTION = 1
+
+type SparklineDatasetItem = VueUiXyDatasetItem & {
+  hasData?: boolean
+  details?: { eligiblePrs: number[]; closedPrs: number[] }
+}
+
+type RepoSelectorOption = {
+  key: string
+  owner: string
+  repo: string
+  hasData: boolean
+  latestValue: string | null
+}
+
+type SparklineChart = SparklineDatasetItem[]
+
+let cachedResultsSource: unknown
+const rawSparklineCache = new Map<string, SparklineChart[]>()
+
+function getScoreBoundsKey(bounds: ScoreBounds) {
+  return `${bounds[0]}-${bounds[1]}`
+}
+
+const rawSparklines = computed<SparklineChart[]>(() => {
+  const results = data.value?.results ?? []
+
+  if (results !== cachedResultsSource) {
+    cachedResultsSource = results
+    rawSparklineCache.clear()
+  }
+
+  const cacheKey = getScoreBoundsKey(scoreBounds.value)
+  const cachedValue = rawSparklineCache.get(cacheKey)
+
+  if (cachedValue) {
+    return cachedValue
+  }
+
+  const nextValue = getClosedPrPercentageEvolutionByRepo(
+    results,
     scoreBounds.value,
-  ).map((dataset) => {
+  ) as SparklineChart[]
+
+  rawSparklineCache.set(cacheKey, nextValue)
+  return nextValue
+})
+
+const GREEN_HUE = 155 // starting at green so we have Nuxt with its color ^^
+
+const repoPalette = Array.from(
+  { length: MAX_SELECTION },
+  (_, i) =>
+    `oklch(72% 0.14 ${(GREEN_HUE + Math.round((i * 360) / MAX_SELECTION)) % 360})`,
+)
+
+function getRepoNameParts(name: string) {
+  const [rawOwner, ...repoParts] = name.split('/')
+  const owner = rawOwner ?? ''
+  const repo = repoParts.join('/')
+
+  return {
+    owner: repo ? owner : '',
+    repo: repo || owner || 'Unknown repository',
+  }
+}
+
+function getLatestDatasetValue(entry?: SparklineDatasetItem) {
+  const rawValue = Array.isArray(entry?.series) ? entry.series.at(-1) : null
+  const value = Number(rawValue)
+
+  return Number.isFinite(value) ? `${value.toFixed(0)}%` : null
+}
+
+const repoOptions = computed<RepoSelectorOption[]>(() => {
+  return rawSparklines.value
+    .map((chart, index) => {
+      const entry = chart[0]
+      const key = entry?.name ?? `repo-${index}`
+      const { owner, repo } = getRepoNameParts(key)
+
+      return {
+        key,
+        owner,
+        repo,
+        hasData: Boolean(entry?.hasData),
+        latestValue: getLatestDatasetValue(entry),
+      }
+    })
+    .filter((option) => option.key)
+})
+
+const selectedRepoNames = shallowRef<string[]>([])
+const selectedRepoColors = shallowRef<Record<string, string>>({})
+
+function getRepoPaletteColor(index: number): string {
+  return repoPalette[index % repoPalette.length] ?? colors.value.textMuted!
+}
+
+function getNormalizedRepoColors(repoNames: string[]) {
+  const usedColors = new Set<string>()
+  const nextColors: Record<string, string> = {}
+
+  for (const repoName of repoNames) {
+    const existingColor = selectedRepoColors.value[repoName]
+    const color =
+      existingColor &&
+      repoPalette.includes(existingColor) &&
+      !usedColors.has(existingColor)
+        ? existingColor
+        : (repoPalette.find((paletteColor) => !usedColors.has(paletteColor)) ??
+          getRepoPaletteColor(usedColors.size))
+
+    nextColors[repoName] = color
+    usedColors.add(color)
+  }
+
+  return nextColors
+}
+
+function areStringArraysEqual(a: string[], b: string[]) {
+  return a.length === b.length && a.every((value, index) => value === b[index])
+}
+
+function areColorMapsEqual(
+  a: Record<string, string>,
+  b: Record<string, string>,
+) {
+  const aEntries = Object.entries(a)
+  const bEntries = Object.entries(b)
+
+  return (
+    aEntries.length === bEntries.length &&
+    aEntries.every(([key, value]) => b[key] === value)
+  )
+}
+
+function setSelectedRepoNames(repoNames: string[]) {
+  const nextColors = getNormalizedRepoColors(repoNames)
+
+  if (!areStringArraysEqual(selectedRepoNames.value, repoNames)) {
+    selectedRepoNames.value = repoNames
+  }
+
+  if (!areColorMapsEqual(selectedRepoColors.value, nextColors)) {
+    selectedRepoColors.value = nextColors
+  }
+}
+
+const selectedRepoColorMap = computed(
+  () => new Map(Object.entries(selectedRepoColors.value)),
+)
+const selectedRepoNameSet = computed(() => new Set(selectedRepoNames.value))
+const selectedRepoCount = computed(() => selectedRepoNames.value.length)
+const selectionLimit = computed(() =>
+  Math.min(MAX_SELECTION, repoOptions.value.length),
+)
+const isSelectionFull = computed(() => selectedRepoCount.value >= MAX_SELECTION)
+
+watch(
+  repoOptions,
+  (options) => {
+    if (!options.length) {
+      setSelectedRepoNames([])
+      return
+    }
+
+    const availableRepoNames = new Set(options.map((option) => option.key))
+    const preservedSelection = selectedRepoNames.value.filter((name) =>
+      availableRepoNames.has(name),
+    )
+
+    if (!preservedSelection.length) {
+      setSelectedRepoNames(
+        options
+          .slice(0, Math.min(DEFAULT_SELECTION, MAX_SELECTION))
+          .map((option) => option.key),
+      )
+      return
+    }
+
+    if (preservedSelection.length !== selectedRepoNames.value.length) {
+      setSelectedRepoNames(preservedSelection)
+      return
+    }
+
+    setSelectedRepoNames(preservedSelection)
+  },
+  { immediate: true },
+)
+
+function isRepoSelected(repoName: string) {
+  return selectedRepoNameSet.value.has(repoName)
+}
+
+function canToggleRepo(repoName: string) {
+  return isRepoSelected(repoName) || !isSelectionFull.value
+}
+
+function toggleRepo(repoName: string) {
+  const isSelected = isRepoSelected(repoName)
+
+  if (isSelected) {
+    if (selectedRepoNames.value.length <= 1) {
+      return
+    }
+
+    setSelectedRepoNames(
+      selectedRepoNames.value.filter((name) => name !== repoName),
+    )
+    return
+  }
+
+  if (selectedRepoNames.value.length >= MAX_SELECTION) {
+    return
+  }
+
+  setSelectedRepoNames([...selectedRepoNames.value, repoName])
+}
+
+function getRepoColor(repoName: string) {
+  return selectedRepoColorMap.value.get(repoName)
+}
+
+function getRepoStyle(repoName: string) {
+  const color = getRepoColor(repoName)
+
+  return {
+    '--repo-color': color ?? 'transparent',
+    '--repo-selected-bg': color
+      ? `color-mix(in oklab, ${color} 12%, transparent)`
+      : 'transparent',
+  } as Record<string, string>
+}
+
+const rawSparklineByRepoName = computed(() => {
+  const map = new Map<string, SparklineChart>()
+
+  for (const chart of rawSparklines.value) {
+    const repoName = chart[0]?.name
+
+    if (repoName) {
+      map.set(repoName, chart)
+    }
+  }
+
+  return map
+})
+
+const selectedRawSparklines = computed<SparklineChart[]>(() => {
+  return selectedRepoNames.value.flatMap((repoName) => {
+    const chart = rawSparklineByRepoName.value.get(repoName)
+    return chart ? [chart] : []
+  })
+})
+
+const sparklines = computed<SparklineChart[]>(() => {
+  return selectedRawSparklines.value.map((dataset) => {
+    const repoName = dataset[0]?.name
+    const repoColor = repoName ? getRepoColor(repoName) : undefined
+
     return dataset.map((datapoint) => ({
       ...datapoint,
-      color: colors.value.textTransparent,
+      color: repoColor ?? selectedRangeColor.value,
       dataLabels: false,
       suffix: '%',
+      smooth: true,
     }))
   })
 })
 
-const selectedIndex = shallowRef<number | undefined>(undefined)
-const selectedChartIndex = shallowRef<number | undefined>(undefined)
+const dataset = computed<VueUiXyDatasetItem[]>(() => sparklines.value.flat())
+
+const chartLineRef = useTemplateRef('chartLineRef')
+const tooltipPositionLine = useTooltipPosition(chartLineRef)
 
 const config = computed<VueUiXyConfig>(() => ({
   useCssAnimation: false,
-  events: {
-    datapointEnter: ({ seriesIndex }) => {
-      selectedIndex.value = seriesIndex
-    },
-    datapointLeave: () => {
-      selectedIndex.value = undefined
-    },
-  },
   chart: {
     userOptions: { show: false },
-    legend: { show: false },
     zoom: { show: false },
-    labels: {
-      fontSize: 16,
-    },
-    tooltip: {
-      show: true,
-      teleportTo: '#sparklines',
-      backgroundOpacity: 0,
-      color: colors.value.text,
-      borderColor: 'transparent',
+    legend: { show: false },
+    backgroundColor: colors.value.bg,
+    height: 350,
+    padding: {
+      right: 100,
+      top: 80,
     },
     highlighter: {
-      opacity: 0,
+      opacity: 5,
       useLine: true,
       lineDasharray: 0,
-      color: selectedRangeColor.value,
+      color: colors.value.textMuted,
     },
-    padding: {
-      top: 6,
-      left: 4,
-      right: 66,
-      bottom: 0,
+    tooltip: {
+      position: tooltipPositionLine.value,
+      backgroundColor: colors.value.bg,
+      color: colors.value.text,
+      borderColor: colors.value.border,
+      backgroundOpacity: 30,
+      offsetX: 42,
+      offsetY: -(selectedRepoCount.value * 18),
     },
-    backgroundColor: colors.value.bg,
-    height: 100,
-    width: 450,
     grid: {
       position: 'start',
       stroke: 'transparent',
       labels: {
         show: false,
+        yAxis: {
+          scaleMin: 0,
+          scaleMax: 100,
+        },
         xAxisLabels: {
           show: false,
           values: dates.value,
@@ -125,10 +387,6 @@ const config = computed<VueUiXyConfig>(() => ({
             },
           },
         },
-        yAxis: {
-          scaleMin: 0,
-          scaleMax: 100,
-        },
       },
     },
   },
@@ -136,18 +394,31 @@ const config = computed<VueUiXyConfig>(() => ({
     radius: 0,
     useGradient: false,
     dot: {
-      useSerieColor: false,
+      useSerieColor: true,
       fill: selectedRangeColor.value,
       strokeWidth: 3,
       selectedRadius: 6,
     },
-    labels: {
-      show: true,
-      color: colors.value.text,
-      offsetY: -12,
-    },
   },
 }))
+
+function drawLastDatapointLabel(svg: VueUiXySvgSlotProps['svg']) {
+  return createLastDatapointLabelsSvg({
+    series: Array.isArray(svg?.data) ? svg.data : [],
+    drawingArea: svg.drawingArea,
+    svgWidth: svg.width,
+    fontSize: 20,
+    labelOffset: 24,
+    colors: {
+      foreground: colors.value.text!,
+      background: colors.value.bg!,
+      fallbackSerieColor: colors.value.textMuted!,
+    },
+    formatValue: (value) =>
+      Number.isFinite(value) ? `${value.toFixed(0)}%` : '-',
+    isDarkMode: isDarkMode.value,
+  })
+}
 
 type SvgSerieItem = {
   id?: string
@@ -166,214 +437,243 @@ function getLastPlotTransform(serie: SvgSerieItem) {
   return `translate(${lastPlot.x}px, ${lastPlot.y}px)`
 }
 
-function getLastPlotLabel(serie: SvgSerieItem) {
-  const lastPlot = getLastPlot(serie)
-  const value = Number(lastPlot?.value ?? 0)
-  return `${value.toFixed(0)}%`
-}
-
-type XyAugmentedSeries = VueUiXySeries[number] & {
+type XyAugmentedSeries = SparklineDatasetItem & {
   details: { eligiblePrs: number[]; closedPrs: number[] }
 }
 
-function getTooltipContent(
-  series: VueUiXyTooltipSlotProps['series'],
-  timeLabel: VueUiXyTooltipSlotProps['timeLabel'],
-) {
-  const { absoluteIndex: index } = timeLabel
-  const datapoint = series[0] as unknown as XyAugmentedSeries
-  const eligible = datapoint?.details?.eligiblePrs?.[index]
-  const closed = datapoint?.details?.closedPrs?.[index]
-  if (closed == null || eligible == null) {
-    return ''
-  }
-  const percentage =
-    eligible === 0 ? 100 : Math.round((closed / eligible) * 100)
-  return `${closed} / ${eligible} (${percentage}%)`
+type TooltipRow = {
+  key: string
+  owner: string
+  repo: string
+  color: string
+  value: string
+  detail: string
 }
 
-function hideDataLabel(chartIndex: number) {
-  return (
-    selectedChartIndex.value === chartIndex ||
-    (selectedIndex.value !== undefined &&
-      selectedIndex.value === (dates.value?.length ?? 0) - 1)
-  )
+function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
+  const { absoluteIndex: index } = timeLabel
+
+  if (!Number.isInteger(index)) {
+    return []
+  }
+
+  return dataset.value.map((datapoint, datasetIndex): TooltipRow => {
+    const entry = datapoint as unknown as XyAugmentedSeries
+    const repoName = entry.name ?? `repo-${datasetIndex}`
+    const { owner, repo } = getRepoNameParts(repoName)
+    const eligible = entry.details?.eligiblePrs?.[index]
+    const closed = entry.details?.closedPrs?.[index]
+    const value = Number(entry.series?.[index])
+    const percentage =
+      closed == null || eligible == null
+        ? value
+        : eligible === 0
+          ? 100
+          : Math.round((closed / eligible) * 100)
+
+    return {
+      key: repoName,
+      owner: owner!,
+      repo,
+      color: getRepoColor(repoName)! ?? colors.value.border,
+      value: Number.isFinite(percentage) ? `${percentage.toFixed(0)}%` : '-',
+      detail:
+        closed == null || eligible == null
+          ? 'No data'
+          : `${closed} / ${eligible}`,
+    }
+  })
 }
 </script>
 
 <template>
-  <div class="mb-5">
-    <h2 class="text-center">
-      Evolution of pull request closure rates by repository for PRs in a given
-      score range.
-    </h2>
-    <p class="text-sm text-gh-muted text-center">
-      Closure rates are based on daily snapshots, not cumulative history, so
-      counts may change from one day to the next.
-    </p>
-  </div>
-
-  <div class="mb-4 flex items-center justify-center gap-6">
-    <label class="font-medium">Score range</label>
-
-    <label class="flex items-center gap-2 cursor-pointer">
-      <input
-        v-model="scoreBounds"
-        type="radio"
-        :value="[0, identityConfig.THRESHOLD_SUSPICIOUS]"
-        class="accent-red"
-      />
-      <span>0-{{ identityConfig.THRESHOLD_SUSPICIOUS }}</span>
-    </label>
-
-    <label class="flex items-center gap-2 cursor-pointer">
-      <input
-        v-model="scoreBounds"
-        type="radio"
-        :value="[
-          identityConfig.THRESHOLD_SUSPICIOUS,
-          identityConfig.THRESHOLD_HUMAN,
-        ]"
-        class="accent-amber"
-      />
-      <span
-        >{{ identityConfig.THRESHOLD_SUSPICIOUS }}-{{
-          identityConfig.THRESHOLD_HUMAN
-        }}</span
+  <section ref="rootEl">
+    <!-- REPO SELECTOR -->
+    <div
+      class="mb-4 rounded-lg max-w-screen sm:max-w-[740px] min-w-0"
+      role="group"
+      aria-label="Repository selector"
+    >
+      <div class="mb-5">
+        <h2 class="text-center">
+          Evolution of pull request closure rates by repository for PRs in a
+          given score range.
+        </h2>
+        <p class="text-sm text-gh-muted text-center">
+          Closure rates are based on daily snapshots, not cumulative history, so
+          counts may change from one day to the next.
+        </p>
+      </div>
+      <div
+        class="mb-3 flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-4"
       >
-    </label>
-
-    <label class="flex items-center gap-2 cursor-pointer">
-      <input
-        v-model="scoreBounds"
-        type="radio"
-        :value="[identityConfig.THRESHOLD_HUMAN, 100]"
-        class="accent-green"
-      />
-      <span>{{ identityConfig.THRESHOLD_HUMAN }}-100</span>
-    </label>
-  </div>
-
-  <div
-    id="sparklines"
-    class="grid grid-cols-2 gap-4 max-w-[600px] mx-auto"
-    :data-loaded="loaded"
-  >
-    <ClientOnly v-for="(chart, chartIndex) in sparklines" :key="chart[0]?.name">
-      <div class="flex flex-col">
-        <div class="text-sm mb-1">
-          <span class="text-gh-muted">{{ chart[0]?.name.split('/')[0] }}/</span>
-          <span>{{ chart[0]?.name.split('/')[1] }}</span>
+        <div>
+          <p class="m-0 text-sm font-semibold leading-tight">
+            Featured repositories
+          </p>
+          <p class="m-0 text-xs text-gh-muted">
+            {{ selectedRepoCount }} / {{ selectionLimit }} selected
+          </p>
         </div>
+        <p class="m-0 max-w-[260px] text-xs text-gh-muted sm:text-right">
+          Pick up to {{ MAX_SELECTION }} repositories. At least one must stay
+          selected.
+        </p>
+      </div>
 
-        <div
-          v-if="chart[0]?.hasData"
-          class="w-full h-full border-gh-border border-l-0.5 border-b-0.5 rounded-bl overflow-hidden"
-          :data-hide-label="hideDataLabel(chartIndex)"
+      <div class="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        <button
+          v-for="option in repoOptions"
+          :key="option.key"
+          type="button"
+          class="flex min-h-8 items-center gap-2 rounded-md border px-2.5 py-1 text-left text-xs transition disabled:cursor-not-allowed disabled:opacity-45 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--bg)]"
+          :class="[
+            isRepoSelected(option.key)
+              ? 'border-[var(--repo-color)] bg-[var(--repo-selected-bg)] focus-visible:ring-[var(--repo-color)]'
+              : 'border-gh-border hover:border-current/30 focus-visible:ring-current/20',
+          ]"
+          :aria-pressed="isRepoSelected(option.key)"
+          :disabled="!canToggleRepo(option.key)"
+          :style="getRepoStyle(option.key)"
+          @click="toggleRepo(option.key)"
         >
-          <VueUiXy
-            :dataset="chart"
-            :config
-            :selected-x-index="selectedIndex"
-            @mouseenter="selectedChartIndex = chartIndex"
+          <span
+            class="h-2.5 w-2.5 rounded-full border"
+            :class="
+              isRepoSelected(option.key)
+                ? 'border-[var(--repo-color)] bg-[var(--repo-color)]'
+                : 'border-gh-border bg-transparent'
+            "
+            aria-hidden="true"
+          />
+          <span class="min-w-0 flex-1 truncate font-medium leading-tight">
+            <span class="text-gh-muted"> {{ option.owner }}/ </span>
+            <span>{{ option.repo }}</span>
+          </span>
+          <span
+            class="shrink-0 px-1.5 py-0.5 text-[11px] leading-none text-gh-muted tabular-nums"
           >
-            <template #tooltip="{ series, timeLabel }">
-              <div class="text-gh-muted flex flex-col text-center text-xs">
-                <span>{{ timeLabel.text }}</span>
-                {{ getTooltipContent(series, timeLabel) }}
-              </div>
-            </template>
+            <span v-if="option.hasData">{{ option.latestValue ?? '—' }}</span>
+            <span v-else>No data</span>
+          </span>
+        </button>
+      </div>
+    </div>
+
+    <div class="max-w-screen sm:max-w-[740px]">
+      <!-- SCORE RANGE SELECTOR -->
+      <div class="mb-4 mt-8 flex items-center justify-center gap-6">
+        <label class="font-medium">Score range</label>
+
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            :checked="isScoreRangeSelected(suspiciousScoreBounds)"
+            class="accent-red"
+            @change="setScoreBounds(suspiciousScoreBounds)"
+          />
+          <span>0-{{ identityConfig.THRESHOLD_SUSPICIOUS }}</span>
+        </label>
+
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            :checked="isScoreRangeSelected(amberScoreBounds)"
+            class="accent-amber"
+            @change="setScoreBounds(amberScoreBounds)"
+          />
+          <span>
+            {{ identityConfig.THRESHOLD_SUSPICIOUS }}-{{
+              identityConfig.THRESHOLD_HUMAN
+            }}
+          </span>
+        </label>
+
+        <label class="flex items-center gap-2 cursor-pointer">
+          <input
+            type="radio"
+            :checked="isScoreRangeSelected(humanScoreBounds)"
+            class="accent-green"
+            @change="setScoreBounds(humanScoreBounds)"
+          />
+          <span>{{ identityConfig.THRESHOLD_HUMAN }}-100</span>
+        </label>
+      </div>
+
+      <div class="min-w-0 max-w-[740px] overflow-hidden">
+        <ClientOnly>
+          <VueUiXy :dataset="dataset" :config="config" ref="chartLineRef">
             <template #svg="{ svg }">
+              <!-- LAST VALUE LABEL -->
+              <g v-html="drawLastDatapointLabel(svg)" />
+
+              <!-- LAST DATAPOINT CIRCLE -->
               <g
                 v-for="serie in Array.isArray(svg?.data) ? svg.data : []"
                 :key="serie.id"
                 class="last-datapoint"
                 :style="{ transform: getLastPlotTransform(serie) }"
               >
-                <text
-                  class="value-label"
-                  text-anchor="start"
-                  dominant-baseline="middle"
-                  x="12"
-                  y="0"
-                  font-size="18"
-                  :fill="colors.text"
-                  :stroke="colors.bg"
-                  stroke-width="1"
-                  paint-order="stroke fill"
-                >
-                  {{ getLastPlotLabel(serie) }}
-                </text>
-
                 <circle
                   class="value-plot"
                   cx="0"
                   cy="0"
                   r="6"
-                  :fill="selectedRangeColor"
+                  :fill="serie.color"
                   :stroke="colors.bg"
                   stroke-width="3"
                 />
               </g>
             </template>
+
+            <!-- CUSTOM TOOLTIP -->
+            <template #tooltip="{ timeLabel }">
+              <div class="min-w-[220px] text-xs">
+                <div class="mb-2 font-medium text-gh-muted">
+                  {{ timeLabel.text }}
+                </div>
+
+                <div class="flex flex-col gap-1.5">
+                  <div
+                    v-for="row in getTooltipRows(timeLabel)"
+                    :key="row.key"
+                    class="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2"
+                  >
+                    <span
+                      class="h-2 w-2 rounded-full"
+                      :style="{ backgroundColor: row.color }"
+                      aria-hidden="true"
+                    />
+                    <span class="min-w-0 truncate text-left">
+                      <span class="text-gh-muted"> {{ row.owner }}/ </span>
+                      <span>{{ row.repo }}</span>
+                    </span>
+                    <span class="text-gh-muted tabular-nums">
+                      {{ row.detail }}
+                    </span>
+                    <span class="font-medium tabular-nums">
+                      {{ row.value }}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </template>
           </VueUiXy>
-        </div>
-        <div
-          v-else
-          class="w-full h-full border-gh-border border-l-0.5 border-b-0.5 rounded-bl flex justify-center place-items-center"
-        >
-          <span class="text-xs text-gh-muted">No data to display</span>
-        </div>
+        </ClientOnly>
       </div>
-    </ClientOnly>
-  </div>
+    </div>
+  </section>
 </template>
 
 <style scoped>
-:deep(.vue-data-ui-component) {
-  --super-ease-out: cubic-bezier(0.15, 0.75, 0.35, 1);
-}
-
-[data-loaded='true'] :deep(.vue-data-ui-component path),
-[data-loaded='true'] :deep(.last-datapoint),
-[data-loaded='true'] :deep(.value-label),
-[data-loaded='true'] :deep(.value-plot) {
-  transition: all 0.5s var(--super-ease-out) !important;
-}
-
-[data-loaded='false'] :deep(.vue-data-ui-component path),
-[data-loaded='false'] :deep(.last-datapoint),
-[data-loaded='false'] :deep(.value-label),
-[data-loaded='false'] :deep(.value-plot) {
+:deep(.vue-data-ui-component path),
+:deep(.last-datapoint),
+:deep(.value-label),
+:deep(.value-plot),
+:deep(.vdui-shape-circle) {
   transition: none !important;
 }
 :deep(.vue-data-ui-component circle) {
   stroke: var(--bg);
-}
-
-:deep(.vdui-shape-circle) {
-  transition: none !important;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  :deep(.vue-data-ui-component path),
-  :deep(.last-datapoint),
-  :deep(.value-label),
-  :deep(.value-plot) {
-    transition: none !important;
-  }
-}
-
-:deep([data-hide-label='true'] svg text:not(.value-label)) {
-  display: none;
-}
-:deep(div:has(.vue-data-ui-xy-svg)) {
-  border-radius: 12px !important;
-}
-</style>
-
-<style>
-#sparklines .vue-data-ui-tooltip {
-  padding: 2px 6px !important;
 }
 </style>

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -475,7 +475,7 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
       key: repoName,
       owner: owner!,
       repo,
-      color: getRepoColor(repoName)! ?? colors.value.border,
+      color: getRepoColor(repoName) ?? colors.value.border ?? 'currentColor',
       value: Number.isFinite(percentage) ? `${percentage.toFixed(0)}%` : '-',
       detail:
         closed == null || eligible == null
@@ -602,9 +602,10 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
 
       <div class="min-w-0 max-w-[740px] overflow-hidden">
         <ClientOnly>
-          <VueUiXy :dataset="dataset" :config="config" ref="chartLineRef">
+          <VueUiXy ref="chartLineRef" :dataset="dataset" :config="config">
             <template #svg="{ svg }">
               <!-- LAST VALUE LABEL -->
+              <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component, vue/no-v-html -->
               <g v-html="drawLastDatapointLabel(svg)" />
 
               <!-- LAST DATAPOINT CIRCLE -->

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -80,7 +80,7 @@ const dataset = computed(() => stacklineData.value.dataset)
     <div
       class="flex flex-col gap-20 items-center justify-center max-w-4xl mx-auto pb-12 w-full px-4"
     >
-      <div>
+      <div class="w-full">
         <ChartHealthResponseSparklines />
       </div>
       <div class="w-full">

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -464,7 +464,9 @@ export function createLastDatapointLabelsSvg({
   const labels = series
     .map((serie) => {
       const lastPlot = Array.isArray(serie.plots) ? serie.plots.at(-1) : null
-      if (!lastPlot) return null
+      if (!lastPlot) {
+        return null
+      }
 
       const value = Number(lastPlot.value ?? 0)
       const safeValue = Number.isFinite(value) ? value : 0
@@ -481,11 +483,15 @@ export function createLastDatapointLabelsSvg({
     })
     .filter(isLastDatapointLabel)
 
-  if (!labels.length) return ''
+  if (!labels.length) {
+    return ''
+  }
 
   const hasCollision = labels.some((label, labelIndex) =>
     labels.some((otherLabel, otherLabelIndex) => {
-      if (labelIndex === otherLabelIndex) return false
+      if (labelIndex === otherLabelIndex) {
+        return false
+      }
 
       return (
         label.x + labelOffset < otherLabel.x + labelOffset + otherLabel.width &&
@@ -533,14 +539,18 @@ export function createLastDatapointLabelsSvg({
   for (let index = 1; index < positionedLabels.length; index += 1) {
     const previousLabel = positionedLabels[index - 1]
     const currentLabel = positionedLabels[index]
-    if (!previousLabel || !currentLabel) continue
+    if (!previousLabel || !currentLabel) {
+      continue
+    }
     if (currentLabel.labelY - previousLabel.labelY < labelHeight) {
       currentLabel.labelY = previousLabel.labelY + labelHeight
     }
   }
 
   const lastLabel = positionedLabels.at(-1)
-  if (!lastLabel) return ''
+  if (!lastLabel) {
+    return ''
+  }
   const overflow = lastLabel.labelY - maximumLabelY
 
   if (overflow > 0) {

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -426,3 +426,189 @@ export function getClosedPrDelta(
           ) / 10,
   }
 }
+
+/**
+ * Utility to be used in vue-data-ui line charts (`VueUiXy`) using the `#svg` slot to display the last value as data label.
+ * In case of mutliple series, if label collisions are detected, labels are distributed as close as possible to their related datapoint,  shifted to avoid overlaps, and linked to the last datapoint with an elbowed marker
+ */
+export function createLastDatapointLabelsSvg({
+  series,
+  drawingArea,
+  colors,
+  formatValue,
+  isDarkMode,
+  fontSize = 20,
+  labelOffset = 24,
+  labelHeight = 30,
+}: {
+  series: LastDatapointLabelSerie[]
+  drawingArea: {
+    top: number
+    height?: number
+    bottom?: number
+  }
+  colors: LastDatapointLabelColors
+  formatValue: (value: number) => string
+  isDarkMode: boolean
+  svgWidth?: number
+  fontSize?: number
+  labelOffset?: number
+  labelHeight?: number
+}) {
+  const drawingAreaTop = Number(drawingArea.top ?? 0)
+  const drawingAreaHeight = Number(
+    drawingArea.height ?? Number(drawingArea.bottom ?? 0) - drawingAreaTop,
+  )
+  const drawingAreaBottom = drawingAreaTop + drawingAreaHeight
+
+  const labels = series
+    .map((serie) => {
+      const lastPlot = Array.isArray(serie.plots) ? serie.plots.at(-1) : null
+      if (!lastPlot) return null
+
+      const value = Number(lastPlot.value ?? 0)
+      const safeValue = Number.isFinite(value) ? value : 0
+      const text = formatValue(safeValue)
+
+      return {
+        x: Number(lastPlot.x ?? 0),
+        y: Number(lastPlot.y ?? 0),
+        value: safeValue,
+        color: String(serie.color ?? colors.fallbackSerieColor),
+        text,
+        width: text.length * fontSize * 0.58,
+      }
+    })
+    .filter(isLastDatapointLabel)
+
+  if (!labels.length) return ''
+
+  const hasCollision = labels.some((label, labelIndex) =>
+    labels.some((otherLabel, otherLabelIndex) => {
+      if (labelIndex === otherLabelIndex) return false
+
+      return (
+        label.x + labelOffset < otherLabel.x + labelOffset + otherLabel.width &&
+        label.x + labelOffset + label.width > otherLabel.x + labelOffset &&
+        label.y - labelHeight / 2 < otherLabel.y + labelHeight / 2 &&
+        label.y + labelHeight / 2 > otherLabel.y - labelHeight / 2
+      )
+    }),
+  )
+
+  if (!hasCollision) {
+    return labels
+      .map(
+        (label) => `
+          <text
+            text-anchor="start"
+            dominant-baseline="middle"
+            x="${label.x + labelOffset}"
+            y="${label.y}"
+            font-size="${fontSize}"
+            fill="${colors.foreground}"
+            stroke="${colors.background}"
+            stroke-width="1"
+            paint-order="stroke fill"
+          >
+            ${label.text}
+          </text>
+        `,
+      )
+      .join('\n')
+  }
+
+  const sortedLabels = [...labels].sort((firstLabel, secondLabel) => {
+    return firstLabel.y - secondLabel.y
+  })
+
+  const minimumLabelY = drawingAreaTop + labelHeight / 2
+  const maximumLabelY = drawingAreaBottom - labelHeight / 2
+
+  const positionedLabels = sortedLabels.map((label) => ({
+    ...label,
+    labelY: Math.min(maximumLabelY, Math.max(minimumLabelY, label.y)),
+  }))
+
+  for (let index = 1; index < positionedLabels.length; index += 1) {
+    const previousLabel = positionedLabels[index - 1]
+    const currentLabel = positionedLabels[index]
+    if (!previousLabel || !currentLabel) continue
+    if (currentLabel.labelY - previousLabel.labelY < labelHeight) {
+      currentLabel.labelY = previousLabel.labelY + labelHeight
+    }
+  }
+
+  const lastLabel = positionedLabels.at(-1)
+  if (!lastLabel) return ''
+  const overflow = lastLabel.labelY - maximumLabelY
+
+  if (overflow > 0) {
+    for (const label of positionedLabels) {
+      label.labelY -= overflow
+    }
+  }
+
+  const labelX =
+    Math.max(...positionedLabels.map((label) => label.x)) + labelOffset + 10
+
+  return positionedLabels
+    .map((label) => {
+      const connectorStartX = label.x + 5
+      const connectorEndX = labelX
+
+      return `
+        <path
+          d="M${connectorStartX},${label.y} ${connectorStartX + 6},${label.y} ${connectorEndX},${label.labelY} ${connectorEndX + 6},${label.labelY}"
+          stroke="${label.color}"
+          stroke-width="1"
+          opacity="${isDarkMode ? '0.7' : '1'}"
+          fill="none"
+        />
+        <text
+          text-anchor="start"
+          dominant-baseline="middle"
+          x="${connectorEndX + 12}"
+          y="${label.labelY}"
+          font-size="${fontSize}"
+          fill="${colors.foreground}"
+          stroke="${colors.background}"
+          stroke-width="1"
+          paint-order="stroke fill"
+        >
+          ${label.text}
+        </text>
+      `
+    })
+    .join('\n')
+}
+
+export type LastDatapointLabelColors = {
+  foreground: string
+  background: string
+  fallbackSerieColor: string
+}
+
+export type LastDatapointLabelSerie = {
+  color?: string
+  plots?: {
+    x?: number | null
+    y?: number | null
+    value?: number | null
+  }[]
+}
+
+type LastDatapointLabel = {
+  x: number
+  y: number
+  value: number
+  color: string
+  text: string
+  width: number
+}
+
+function isLastDatapointLabel(
+  label: LastDatapointLabel | null,
+): label is LastDatapointLabel {
+  return label !== null
+}

--- a/test/unit/shared/utils/charts.test.ts
+++ b/test/unit/shared/utils/charts.test.ts
@@ -9,6 +9,7 @@ import {
   getClosedPrPercentageEvolutionTotal,
   getClosedPrPercentageTotal,
   getClosedPrDelta,
+  createLastDatapointLabelsSvg,
 } from '../../../../shared/utils/charts'
 import {
   EXPECTED_NB_UNIQUE_REPOS,
@@ -356,5 +357,297 @@ describe('getClosedPrDelta', () => {
       },
       percentagePointDifference: null,
     })
+  })
+})
+
+const colors = {
+  foreground: '#000000',
+  background: '#FFFFFF',
+  fallbackSerieColor: '#999999',
+}
+
+describe('createLastDatapointLabelsSvg', () => {
+  it('returns an empty string when there are no series', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [],
+      drawingArea: { top: 10, height: 100 },
+      colors,
+      formatValue: (value) => String(value),
+      isDarkMode: false,
+    })
+
+    expect(result).toBe('')
+  })
+
+  it('returns an empty string when no serie has plots', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ color: '#FF0000' }, { color: '#00FF00', plots: [] }],
+      drawingArea: { top: 10, height: 100 },
+      colors,
+      formatValue: (value) => String(value),
+      isDarkMode: false,
+    })
+
+    expect(result).toBe('')
+  })
+
+  it('renders regular labels when there is no collision', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 20, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 90, value: 20 }] },
+      ],
+      drawingArea: { top: 0, height: 120 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('<text')
+    expect(result).not.toContain('<path')
+    expect(result).toContain('x="124"')
+    expect(result).toContain('y="20"')
+    expect(result).toContain('y="90"')
+    expect(result).toContain('10')
+    expect(result).toContain('20')
+  })
+
+  it('uses custom font size, label offset, and colors in regular labels', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 10, y: 20, value: 42 }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+      fontSize: 12,
+      labelOffset: 10,
+    })
+
+    expect(result).toContain('x="20"')
+    expect(result).toContain('font-size="12"')
+    expect(result).toContain('fill="#000000"')
+    expect(result).toContain('stroke="#FFFFFF"')
+  })
+
+  it('uses only the last plot of each serie', () => {
+    const formatValue = vi.fn((value: number) => `${value}`)
+
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        {
+          color: '#FF0000',
+          plots: [
+            { x: 10, y: 10, value: 1 },
+            { x: 50, y: 50, value: 99 },
+          ],
+        },
+      ],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue,
+      isDarkMode: false,
+    })
+
+    expect(formatValue).toHaveBeenCalledTimes(1)
+    expect(formatValue).toHaveBeenCalledWith(99)
+    expect(result).toContain('x="74"')
+    expect(result).toContain('y="50"')
+    expect(result).not.toContain('x="34"')
+  })
+
+  it('formats safe numeric values and falls back to zero for invalid values', () => {
+    const formatValue = vi.fn((value: number) => `value:${value}`)
+
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 10, y: 20, value: Number.NaN }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue,
+      isDarkMode: false,
+    })
+
+    expect(formatValue).toHaveBeenCalledWith(0)
+    expect(result).toContain('value:0')
+  })
+
+  it('renders collision labels as a compact non-overlapping label rack', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 30 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 60, value: 20 }] },
+      ],
+      drawingArea: { top: 10, height: 120 },
+      colors,
+      formatValue: (value) => `value-${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('<path')
+    expect(result).toContain('opacity="1"')
+    expect(result).toContain('stroke="#00FF00"')
+    expect(result).toContain('stroke="#0000FF"')
+    expect(result).toContain('stroke="#FF0000"')
+    expect(result.indexOf('value-10')).toBeLessThan(result.indexOf('value-30'))
+    expect(result.indexOf('value-30')).toBeLessThan(result.indexOf('value-20'))
+    expect(result).toContain('y="50"')
+    expect(result).toContain('y="80"')
+    expect(result).toContain('y="110"')
+  })
+
+  it('uses drawingArea.bottom when height is not provided', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 20 }] },
+      ],
+      drawingArea: { top: 20, bottom: 120 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('y="50"')
+    expect(result).toContain('y="80"')
+  })
+
+  it('keeps colliding labels close to their related points without overlapping', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 40, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 45, value: 20 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 95, value: 30 }] },
+      ],
+      drawingArea: { top: 0, height: 120 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('y="40"')
+    expect(result).toContain('y="70"')
+    expect(result).toContain('y="100"')
+  })
+
+  it('shifts the label stack upward when it overflows the drawing area bottom', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 80, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 85, value: 20 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 90, value: 30 }] },
+      ],
+      drawingArea: { top: 0, height: 120 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('y="45"')
+    expect(result).toContain('y="75"')
+    expect(result).toContain('y="105"')
+  })
+
+  it('uses dark-mode opacity in collision mode', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: true,
+    })
+
+    expect(result).toContain('opacity="0.7"')
+  })
+
+  it('uses the fallback serie color when no color is provided', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { plots: [{ x: 100, y: 50, value: 10 }] },
+        { plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('stroke="#999999"')
+  })
+
+  it('supports null plot values from SSR slot data', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 10, y: 20, value: null }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: (value) => `formatted:${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('formatted:0')
+  })
+
+  it('uses zero defaults when plot coordinates are nullish', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: null, y: null, value: undefined }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: (value) => `value-${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('x="24"')
+    expect(result).toContain('y="0"')
+    expect(result).toContain('value-0')
+  })
+
+  it('uses zero drawing area height when neither height nor bottom is provided', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 20 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('y="-45"')
+    expect(result).toContain('y="-15"')
+  })
+
+  it('renders a regular label when serie color is omitted', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [{ plots: [{ x: 100, y: 50, value: 10 }] }],
+      drawingArea: { top: 0, height: 100 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+    })
+
+    expect(result).toContain('<text')
+    expect(result).not.toContain('<path')
+    expect(result).toContain('x="124"')
+    expect(result).toContain('10')
+  })
+
+  it('supports custom labelHeight in collision rack mode', () => {
+    const result = createLastDatapointLabelsSvg({
+      series: [
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+      ],
+      drawingArea: { top: 10, height: 110 },
+      colors,
+      formatValue: (value) => `${value}`,
+      isDarkMode: false,
+      labelHeight: 20,
+    })
+
+    expect(result).toContain('y="50"')
+    expect(result).toContain('y="70"')
   })
 })


### PR DESCRIPTION
Closes #233 

A selection of repos can now be displayed on a single chart instead of the multiple sparklines, and makes it easier to compare repos.

The selection is not persisted in localStorage for now (I don't think it would bring anything to the table). The component loads with the first item selected. A max of 5 repos can be selected, to not overwhelm the chart with series.

<img width="894" height="938" alt="image" src="https://github.com/user-attachments/assets/cbaa84bb-29f2-4bcf-9cf4-84d62009e5c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the health response chart to support interactive score-range filtering and selecting featured repositories.
  * Added a last-datapoint label display with dark-mode-aware styling and smarter label placement for overlapping charts.

* **Bug Fixes**
  * Improved tooltip details so users see clearer per-repository status and “No data” handling when information is missing.
  * Reduced unnecessary chart updates by making selection and color handling more consistent.

* **Tests**
  * Added coverage for the new SVG label rendering behavior and key edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->