### PR TITLE
feat: add account event breakdown chart

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -9,6 +9,7 @@
 :root[data-theme='dark'] {
   --bg: #0b0b0b;
   --card: #161616;
+  --card-light: #262626;
   --border: #575757;
   --border-light: #757575;
   --text: #f0f0f0;
@@ -49,6 +50,7 @@
 :root[data-theme='light'] {
   --bg: #f6f8fa;
   --card: #ffffff;
+  --card-light: #d0d7de;
   --border: #b7b7b7;
   --border-light: #d0d7de;
   --text: #222222;

--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -239,11 +239,14 @@ useSeoAnalysis(identifyAnalysis, {
     />
 
     <ChartAccountEventsTimeline
-      v-if="data.analysis.classification !== 'organic'"
       :classification="data.analysis.classification"
       :events="data.events"
     />
 
+    <ChartAccountEventsBreakdown
+      :classification="data.analysis.classification"
+      :events="data.events"
+    />
     <p
       class="mt-8 mx-auto max-w-md text-xs text-gh-muted/60 leading-relaxed text-pretty text-center"
     >

--- a/app/components/Chart/AccountEventsBreakdown.vue
+++ b/app/components/Chart/AccountEventsBreakdown.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import type { GitHubEvent, IdentityClassification } from '@unveil/identity'
+import {
+  VueUiHorizontalBar,
+  type VueUiHorizontalBarDatasetItem,
+  type VueUiHorizontalBarConfig,
+} from 'vue-data-ui/vue-ui-horizontal-bar'
+import type { EventTaxonomyKey } from '~~/shared/utils/event-taxonomy'
+
+import('vue-data-ui/style.css')
+
+const props = defineProps<{
+  events: GitHubEvent[]
+  classification?: IdentityClassification
+}>()
+
+const rootEl = shallowRef<HTMLElement | null>(null)
+
+onMounted(async () => {
+  rootEl.value = document.documentElement
+})
+
+const colors = useColors(rootEl)
+const { taxonomy } = useEventsTaxonomy(colors, props.classification)
+
+function isEventTaxonomyKey(value: unknown): value is EventTaxonomyKey {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(taxonomy.value, value)
+  )
+}
+
+function createDataset(events: GitHubEvent[]): VueUiHorizontalBarDatasetItem[] {
+  const totals = events.reduce<Record<string, number>>((accumulator, event) => {
+    if (typeof event.type !== 'string') {
+      return accumulator
+    }
+
+    accumulator[event.type] = (accumulator[event.type] ?? 0) + 1
+
+    return accumulator
+  }, {})
+
+  return Object.entries(totals).map(([eventType, total]) => {
+    const taxonomyEntry = isEventTaxonomyKey(eventType)
+      ? taxonomy.value[eventType]
+      : undefined
+
+    const color =
+      taxonomyEntry && 'color' in taxonomyEntry
+        ? (taxonomyEntry.color ?? colors.value.cardLight)
+        : colors.value.cardLight
+
+    return {
+      name: taxonomyEntry?.name ?? eventType,
+      value: total,
+      color,
+    }
+  })
+}
+
+const dataset = computed<VueUiHorizontalBarDatasetItem[]>(() =>
+  createDataset(props.events),
+)
+
+const config = computed<VueUiHorizontalBarConfig>(() => ({
+  userOptions: { show: false },
+  style: {
+    chart: {
+      backgroundColor: colors.value.bg,
+      legend: { show: false },
+      height: Math.max(70, (dataset.value.length + 1) * 16),
+      layout: {
+        bars: {
+          gap: 6,
+          useGradient: false,
+          borderRadius: 1,
+          underlayerColor: colors.value.bg,
+          dataLabels: {
+            color: colors.value.textMuted,
+            fontSize: 9,
+          },
+          nameLabels: {
+            color: colors.value.textMuted,
+            fontSize: 9,
+          },
+        },
+        highlighter: {
+          opacity: 0,
+          color: colors.value.text,
+        },
+      },
+      tooltip: { show: false },
+    },
+  },
+}))
+
+const isExpanded = shallowRef(false)
+function toggleExpanded() {
+  isExpanded.value = !isExpanded.value
+}
+</script>
+
+<template>
+  <div v-if="events.length">
+    <button
+      class="mx-auto flex w-fit flex-wrap items-center gap-2 mb-1 text-left text-sm text-gh-muted"
+      @click="toggleExpanded"
+    >
+      <h4>Events breakdown</h4>
+      <span
+        class="i-lucide:chevron-down ml-auto mt-0.5 shrink-0 text-sm text-gh-muted transition-transform"
+        :class="isExpanded && 'rotate-180'"
+      />
+    </button>
+
+    <div v-if="isExpanded">
+      <ClientOnly>
+        <VueUiHorizontalBar :dataset :config />
+      </ClientOnly>
+    </div>
+  </div>
+</template>

--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -213,7 +213,12 @@ const timeLabels = computed<string[]>(() => {
 const hasEnoughDays = computed<boolean>(() => eventDays.value.length > 1)
 
 const hasEnoughHours = computed<boolean>(() => {
-  return !usesHourlyGranularity.value || timeLabels.value.length > 1
+  // Short hourly spans for organic accounts are more likely to show useless data, threfore there is no need to show the hourly chart with little hours.
+  // However, since mixed/automated accounts can possibly condense a lot of events in a few hours, we allow fewer hours to condition the display.
+  return (
+    !usesHourlyGranularity.value ||
+    timeLabels.value.length > (props.classification === 'organic' ? 5 : 1)
+  )
 })
 
 const hasEnoughDataPoints = computed<boolean>(() => {
@@ -244,20 +249,25 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
     counts[event.type][label] = (counts[event.type][label] || 0) + 1
   }
 
-  const individualEvents: VueUiXyDatasetItem[] = activeGitHubEventTypes.map(
-    (eventType) => {
+  const individualEvents: VueUiXyDatasetItem[] = activeGitHubEventTypes
+    .map((eventType) => {
       const config = eventConfig.value[eventType]
+      const series = timeLabels.value.map(
+        (label) => counts[eventType][label] || 0,
+      )
+
       return {
-        type: 'line',
+        type: 'line' as const,
         useArea: true,
         smooth: true,
         name: config.name,
         color: config.color,
         threshold: config.threshold,
-        series: timeLabels.value.map((label) => counts[eventType][label] || 0),
+        series,
+        visible: series.reduce((sum, value) => sum + (value ?? 0), 0) > 0,
       }
-    },
-  )
+    })
+    .filter((event) => event.visible)
 
   const totalEvents: VueUiXyDatasetItem = {
     type: 'line',
@@ -270,6 +280,10 @@ function createLineDataset(events: GitHubEvent[]): VueUiXyDatasetItem[] {
         return total + Number(event.series[index])
       }, 0)
     }),
+  }
+
+  if (individualEvents.length === 1) {
+    return individualEvents
   }
 
   return [...individualEvents, totalEvents]

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -85,6 +85,7 @@ export function useColors(
     [
       '--bg',
       '--card',
+      '--card-light',
       '--border',
       '--border-light',
       '--text',

--- a/app/composables/useEventsTaxonomy.ts
+++ b/app/composables/useEventsTaxonomy.ts
@@ -1,0 +1,97 @@
+import type { IdentityClassification } from '@unveil/identity'
+
+// GitHub events as listed on https://docs.github.com/en/rest/using-the-rest-api/github-event-types (2026-03-10 version of the API)
+// Descriptions are taken from there
+export function useEventsTaxonomy(
+  colors: Ref<Record<string, string>>,
+  classification: IdentityClassification = 'mixed',
+) {
+  const taxonomy = computed<EventTaxonomy>(() => ({
+    CommitCommentEvent: {
+      name: 'Commit comment event',
+      description: 'A commit comment is created.',
+    },
+    CreateEvent: {
+      name: 'Create event',
+      description: 'A Git branch or tag is created.',
+      color: {
+        organic: colors.value.eventOrganicBranch,
+        mixed: colors.value.eventMixedBranch,
+        automation: colors.value.eventAutomationBranch,
+      }[classification],
+    },
+    DeleteEvent: {
+      name: 'Delete event',
+      description: 'A Git branch or tag is deleted.',
+    },
+    DiscussionEvent: {
+      name: 'Discussion event',
+      description: 'A discussion is created in a repository.',
+    },
+    ForkEvent: {
+      name: 'Fork event',
+      description: 'A user forks a repository.',
+      color: {
+        organic: colors.value.eventOrganicFork,
+        mixed: colors.value.eventMixedFork,
+        automation: colors.value.eventAutomationFork,
+      }[classification],
+    },
+    GollumEvent: {
+      name: 'Gollum event',
+      description: 'A wiki page is created or updated.',
+    },
+    IssueCommentEvent: {
+      name: 'Issue comment event',
+      description: 'Activity related to an issue or pull request comment.',
+    },
+    IssuesEvent: {
+      name: 'Issues event',
+      description: 'Activity related to an issue.',
+    },
+    MemberEvent: {
+      name: 'Member event',
+      description: 'Activity related to repository collaborators.',
+    },
+    PublicEvent: {
+      name: 'Public event',
+      description: 'When a private repository is made public.',
+    },
+    PullRequestEvent: {
+      name: 'Pull request event',
+      description: 'Activity related to pull requests.',
+      color: {
+        organic: colors.value.eventOrganicPr,
+        mixed: colors.value.eventMixedPr,
+        automation: colors.value.eventAutomationPr,
+      }[classification],
+    },
+    PullRequestReviewEvent: {
+      name: 'PR review event',
+      description: 'Activity related to pull request reviews.',
+    },
+    PullRequestReviewCommentEvent: {
+      name: 'PR review comment event',
+      description:
+        "Activity related to pull request review comments in the pull request's unified diff.",
+    },
+    PushEvent: {
+      name: 'Push event',
+      description:
+        'One or more commits are pushed to a repository branch or tag.',
+    },
+    ReleaseEvent: {
+      name: 'Release event',
+      description: 'Activity related to a release.',
+    },
+    WatchEvent: {
+      name: 'Watch event',
+      description:
+        'A user stars a repository (historically referred to as "watching").',
+    },
+  }))
+
+  return {
+    taxonomy,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.22.0",
+    "vue-data-ui": "^3.22.9",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.22.0
-        version: 3.22.0(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.22.9
+        version: 3.22.9(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -5541,8 +5541,8 @@ packages:
   vue-bundle-renderer@2.2.0:
     resolution: {integrity: sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg==}
 
-  vue-data-ui@3.22.0:
-    resolution: {integrity: sha512-FwEv+dtzrIny8jYR1qQ8Ye6IYMA7MDCy+86LQAldV5n/iWF1Ebfx6LI8LHfOBXL7mMZLZ0kggeukGo9y1Ssuyw==}
+  vue-data-ui@3.22.9:
+    resolution: {integrity: sha512-DDSGEVsXo59bJ9BhNKd7MF5SWagWV0bGt/y+C4O4o06bRqSS9JcFRBKykaK0undqyfjZY86PLiEUDunu//S8GA==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -11471,7 +11471,7 @@ snapshots:
     dependencies:
       ufo: 1.6.4
 
-  vue-data-ui@3.22.0(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.22.9(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 

--- a/shared/utils/event-taxonomy.ts
+++ b/shared/utils/event-taxonomy.ts
@@ -1,0 +1,9 @@
+export type EventTaxonomyItem = {
+  name: string
+  description: string
+  color?: string
+}
+
+export type EventTaxonomy = Record<string, EventTaxonomyItem>
+
+export type EventTaxonomyKey = keyof EventTaxonomy


### PR DESCRIPTION
User page:

Since the line chart only graphs a selection of events, it can be surprising for users to feel it does not match the 'real' activity  of the account.

This adds a bar chart to breakdown all 300 events.
For the event types featured on the line chart, the same color scheme is used for the related datapoints on the bar chart.
Other events have the same neutral color.

<img width="829" height="753" alt="image" src="https://github.com/user-attachments/assets/602e2556-0997-498d-bb89-9d7c20278877" />

## Other
- bump vue-data-ui to latest
- only show series on the line chart if they have any data
- hide the line chart for organic profiles when they hit the hourly granularity and the number of hour-ticks are < 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable Events breakdown chart showing activity by event type.
  * Added descriptive labels and color coding for recognized event categories.
  * Events breakdown is now available for all classifications, including organic activity.

* **Bug Fixes**
  * Improved timeline charts by hiding empty event series and avoiding redundant combined activity lines.
  * Adjusted hourly chart visibility based on the amount and type of available activity.

* **Style**
  * Added theme-aware card colors for light and dark modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->