### PR TITLE
chore: housekeeping

### DIFF
--- a/app/components/Chart/GlobalEventsHeatmap.vue
+++ b/app/components/Chart/GlobalEventsHeatmap.vue
@@ -120,7 +120,7 @@ const baseConfig = computed<VueUiHeatmapConfig>(() => ({
     backgroundColor: colors.value.bg,
     color: colors.value.textMuted,
     layout: {
-      width: numberOfWeeks.value * 43,
+      width: 43 + numberOfWeeks.value * 32,
       cells: {
         spacing: 0,
         colors: {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.22.9",
+    "vue-data-ui": "^3.22.11",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.22.9
-        version: 3.22.9(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.22.11
+        version: 3.22.11(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -5737,8 +5737,8 @@ packages:
   vue-bundle-renderer@2.2.0:
     resolution: {integrity: sha512-sz/0WEdYH1KfaOm0XaBmRZOWgYTEvUDt6yPYaUzl4E52qzgWLlknaPPTTZmp6benaPTlQAI/hN1x3tAzZygycg==}
 
-  vue-data-ui@3.22.9:
-    resolution: {integrity: sha512-DDSGEVsXo59bJ9BhNKd7MF5SWagWV0bGt/y+C4O4o06bRqSS9JcFRBKykaK0undqyfjZY86PLiEUDunu//S8GA==}
+  vue-data-ui@3.22.11:
+    resolution: {integrity: sha512-OEK7Wc9Gf5iUYR0z0wD2/hhUo6M52K5YNb2hpnt/21icRZLKq481IBVobvFYXA/sjUZfuUT32hrRqvC/6MLzag==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -11989,7 +11989,7 @@ snapshots:
     dependencies:
       ufo: 1.6.4
 
-  vue-data-ui@3.22.9(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.22.11(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 


### PR DESCRIPTION
A bit of housekeeping:

- bump vue-data-ui to latest
- attempt to correct the dynamic width of lab heatmap charts which cells were stretching too much when new weeks were added. Use a fixed width base to account for label width, and keep the dynamic aspect based on the number of weeks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heatmap sizing so layouts render more consistently across different time ranges.

* **Improvements**
  * Updated the charting component dependency to improve compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->