### PR TITLE
feat(scan): add merged status to scanned prs

### DIFF
--- a/scripts/scan-users.ts
+++ b/scripts/scan-users.ts
@@ -8,6 +8,7 @@ import { Octokit } from 'octokit'
 import type { IdentifyResult } from '@unveil/identity'
 import { hashPrId } from './pr-hash'
 import { pack, unpack } from '../shared/utils/compactor'
+import type { PrStatus } from '../shared/types/ecosystem-health'
 
 // Configuration
 const API_TIMEOUT = 30000
@@ -26,7 +27,7 @@ interface ScanResult {
   events_count: number
   repo_name: string
   pr_key: string
-  pr_status: string
+  pr_status: PrStatus
   is_bounty: boolean
 }
 
@@ -125,7 +126,7 @@ async function searchUsers(
     public_repos: number
     repo_name: string
     pr_key: string
-    pr_status: string
+    pr_status: PrStatus
   }> = []
 
   for (const repoFullName of libraries) {
@@ -168,7 +169,7 @@ async function searchUsers(
         login: fullProfile.data.login,
         created_at: fullProfile.data.created_at,
         pr_key: hashPrId(repoFullName, pr.number),
-        pr_status: pr.state,
+        pr_status: pr.merged_at ? 'merged' : (pr.state as PrStatus),
         public_repos: fullProfile.data.public_repos,
         repo_name: repoFullName,
       })

--- a/shared/types/ecosystem-health.ts
+++ b/shared/types/ecosystem-health.ts
@@ -1,11 +1,13 @@
 import type { calcLinearProgression } from '../utils/calc-linear-progression'
 import type { IdentityClassification } from '@unveil/identity'
 
+export type PrStatus = 'open' | 'closed' | 'merged'
+
 export type EcosystemHealthItem = {
   created_at: string
   score: number
   pr_key: string
-  pr_status: string // FIXME: narrow down
+  pr_status: PrStatus
   user_created_at: string
   user_public_repos_count: number
   events_count: number

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -78,6 +78,7 @@ export type RepoClosedPrOptions = {
   scoreBounds?: ScoreBounds
   openState?: string
   closedState?: string
+  mergedState?: string
   includeAlreadyClosed?: boolean
 }
 
@@ -93,6 +94,7 @@ export function getClosedPrPercentageByRepo(
     scoreBounds = [0, 100],
     openState = 'open',
     closedState = 'closed',
+    mergedState = 'merged',
   } = options
 
   const resolvedScoreBounds: ScoreBounds = Array.isArray(scoreBounds)
@@ -140,7 +142,9 @@ export function getClosedPrPercentageByRepo(
           !Number.isNaN(score) &&
           score >= minScore &&
           score <= maxScore &&
-          (status === openState || status === closedState)
+          (status === openState ||
+            status === closedState ||
+            status === mergedState)
         )
       })
 
@@ -219,7 +223,9 @@ export type ClosedPrPercentageEvolutionSeries = {
  * - Only entries where `dateKey` matches that given day are considered
  * - PRs are deduped by `pr_key`
  * - A PR is considered closed if at least one entry for that PR on that day has a closed status
- * - A PR is considered eligible if it has at least one entry within the selected score range for that day
+ *   (a merged PR does not count as closed — merging is a positive outcome, not a rejection)
+ * - A PR is considered eligible if it has at least one entry within the selected score range for that day,
+ *   whether open, closed, or merged
  *
  * Closure rate is calculated as:
  *

--- a/shared/utils/compactor.ts
+++ b/shared/utils/compactor.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import type { EcosystemHealthItem } from '../types/ecosystem-health'
+import type { EcosystemHealthItem, PrStatus } from '../types/ecosystem-health'
 
 // Compact CSV format for scan results — ~72% smaller than pretty-printed JSON.
 //
@@ -9,12 +9,20 @@ import type { EcosystemHealthItem } from '../types/ecosystem-health'
 //
 //   created_ts / user_ts : unix seconds (drops sub-second precision)
 //   pr_key               : base64url, no padding  (64 hex → 43 chars)
-//   status               : "o" = open | "c" = closed
+//   status               : "o" = open | "c" = closed | "m" = merged
 //   repo_idx             : index into the REPOS header
 //   is_bounty            : 1 = bounty hunter | 0 = not
 
-const STATUS_ENCODE: Record<string, string> = { open: 'o', closed: 'c' }
-const STATUS_DECODE: Record<string, string> = { o: 'open', c: 'closed' }
+const STATUS_ENCODE: Record<string, string> = {
+  open: 'o',
+  closed: 'c',
+  merged: 'm',
+}
+const STATUS_DECODE: Record<string, string> = {
+  o: 'open',
+  c: 'closed',
+  m: 'merged',
+}
 
 function hexToBase64Url(hex: string): string {
   return Buffer.from(hex, 'hex').toString('base64url')
@@ -116,7 +124,7 @@ export function unpack(content: string): EcosystemHealthItem[] {
       created_at: fromUnixSecs(numCreatedTs),
       score: Number(score),
       pr_key: base64UrlToHex(prKeyB64!),
-      pr_status: STATUS_DECODE[status!] ?? status!,
+      pr_status: (STATUS_DECODE[status!] ?? status!) as PrStatus,
       user_created_at: fromUnixSecs(numUserCreatedTs),
       user_public_repos_count: numPublicRepos,
       events_count: numEvents,

--- a/test/unit/shared/utils/charts.test.ts
+++ b/test/unit/shared/utils/charts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, vi, expect, it } from 'vitest'
 import {
   getCompleteDayRange,
   getDayKey,

--- a/test/unit/shared/utils/charts.test.ts
+++ b/test/unit/shared/utils/charts.test.ts
@@ -137,6 +137,34 @@ describe('getClosedPrPercentageByRepo', () => {
       }),
     )
   })
+
+  it('counts merged PRs as eligible but not closed — merging is a positive outcome', () => {
+    const source: EcosystemHealthItem[] = [
+      {
+        repo_name: 'some/repo',
+        pr_key: 'pr-1',
+        pr_status: 'merged',
+        score: 25,
+      } as EcosystemHealthItem,
+      {
+        repo_name: 'some/repo',
+        pr_key: 'pr-2',
+        pr_status: 'closed',
+        score: 25,
+      } as EcosystemHealthItem,
+    ]
+
+    const result = getClosedPrPercentageByRepo(source, {})
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        repo: 'some/repo',
+        eligiblePrs: 2,
+        closedPrs: 1,
+        percentage: 50,
+      }),
+    ])
+  })
 })
 
 describe('getUniqueDatesFromSource', () => {

--- a/test/unit/shared/utils/compactor.test.ts
+++ b/test/unit/shared/utils/compactor.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { pack, unpack } from '../../../../shared/utils/compactor'
+import type { EcosystemHealthItem } from '../../../../shared/types/ecosystem-health'
+
+const ITEMS: EcosystemHealthItem[] = [
+  {
+    created_at: '2026-05-26T19:27:30.000Z',
+    score: 100,
+    pr_key: 'a1b2c3d4',
+    pr_status: 'open',
+    user_created_at: '2017-05-15T12:06:30.000Z',
+    user_public_repos_count: 869,
+    events_count: 200,
+    repo_name: 'nuxt/nuxt',
+    is_bounty: false,
+  },
+  {
+    created_at: '2026-05-26T19:27:30.000Z',
+    score: 40,
+    pr_key: 'e5f6a7b8',
+    pr_status: 'closed',
+    user_created_at: '2026-05-23T17:48:23.000Z',
+    user_public_repos_count: 2,
+    events_count: 20,
+    repo_name: 'nuxt/nuxt',
+    is_bounty: false,
+  },
+  {
+    created_at: '2026-05-26T19:27:30.000Z',
+    score: 40,
+    pr_key: 'c9d0e1f2',
+    pr_status: 'merged',
+    user_created_at: '2026-05-23T17:48:23.000Z',
+    user_public_repos_count: 2,
+    events_count: 20,
+    repo_name: 'nuxt/nuxt',
+    is_bounty: true,
+  },
+]
+
+describe('pack / unpack', () => {
+  it('round-trips open, closed and merged PR statuses', () => {
+    const packed = pack(ITEMS)
+    const unpacked = unpack(packed)
+
+    expect(unpacked).toEqual(ITEMS)
+  })
+
+  it('encodes merged PRs distinctly from closed PRs', () => {
+    const packed = pack(ITEMS)
+    const lines = packed.split('\n')
+
+    expect(lines[1]?.split(',')[3]).toBe('o')
+    expect(lines[2]?.split(',')[3]).toBe('c')
+    expect(lines[3]?.split(',')[3]).toBe('m')
+  })
+})


### PR DESCRIPTION
uses the merged_at property to determine whether the PR has been successfully merged or just closed, since "merged" generally has a positive connotation, whereas "closed" is seen as undesirable.

Both statuses do not necessarily indicate success or failure individually, but on a broader level, they do.

<img width="571" height="343" alt="Screenshot 2026-07-17 at 14 35 58" src="https://github.com/user-attachments/assets/79a652ab-2d4b-40c2-b71f-c6ac235e8896" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a distinct **merged** pull-request status across ecosystem health processing.
  - Updated closure-rate metrics so **merged PRs count as eligible** but **only closed PRs count toward closure totals**.

- **Bug Fixes**
  - Ensured merged PR status is correctly preserved when ecosystem health data is compacted and restored.

- **Tests**
  - Added unit tests validating merged eligibility/closure behavior and pack/unpack round-trip correctness for `open`, `closed`, and `merged`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->