### PR TITLE
feat: extend landmarks

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -348,7 +348,7 @@ const visibleLandmarkByIndex = computed(() => {
                       opacity="1"
                     >
                       <title>{{ landmark.name }}</title>
-                      <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component, vue/no-v-html -->
+                      <!-- eslint-disable vue/no-v-text-v-html-on-component, vue/no-v-html -->
                       <g
                         transform="translate(-7.68, -7.68) scale(0.64)"
                         stroke="currentColor"
@@ -358,7 +358,7 @@ const visibleLandmarkByIndex = computed(() => {
                         fill="none"
                         v-html="landmark.iconSvg"
                       />
-                      <!-- eslint-enable vue/no-v-text-v-html-on-component, vue/no-v-html -->
+                      <!-- eslint-disable vue/no-v-text-v-html-on-component, vue/no-v-html -->
                     </g>
                   </g>
                 </template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -298,12 +298,14 @@ const keyDates = computed(() => {
 
 const isChartHovered = shallowRef(false)
 
-const visibleLandmarkByIndex = computed(() => {
-  const landmarkMap = new Map<number, (typeof keyDates.value)[number]>()
+const visibleLandmarksByIndex = computed(() => {
+  const landmarkMap = new Map<number, Landmark[]>()
   keyDates.value.forEach((landmark) => {
-    if (landmark?.visible) {
-      landmarkMap.set(landmark.index, landmark)
+    if (!landmark?.visible) {
+      return
     }
+    const existingLandmarks = landmarkMap.get(landmark.index) ?? []
+    landmarkMap.set(landmark.index, [...existingLandmarks, landmark])
   })
   return landmarkMap
 })
@@ -487,30 +489,24 @@ function placeLandmark({
                   </template>
                 </div>
 
-                <!-- LANDMARK INFO-->
+                <!-- LANDMARK INFO -->
                 <div
-                  v-if="visibleLandmarkByIndex.has(timeLabel.absoluteIndex)"
-                  class="mt-2 text-xs text-gh-muted"
+                  v-if="visibleLandmarksByIndex.has(timeLabel.absoluteIndex)"
+                  class="mt-2 flex flex-col gap-2 text-xs text-gh-muted"
                 >
-                  <div class="flex flex-row gap-2 max-w-[200px]">
-                    <span
-                      class="w-6"
-                      :class="
-                        visibleLandmarkByIndex.get(timeLabel.absoluteIndex)
-                          ?.icon
-                      "
-                    />
-                    <span
-                      >{{
-                        visibleLandmarkByIndex.get(timeLabel.absoluteIndex)
-                          ?.name
-                      }}
-                      :
-                      {{
-                        visibleLandmarkByIndex.get(timeLabel.absoluteIndex)
-                          ?.description
-                      }}</span
-                    >
+                  <div
+                    v-for="landmark in visibleLandmarksByIndex.get(
+                      timeLabel.absoluteIndex,
+                    ) ?? []"
+                    :key="`${landmark.date}-${landmark.name}-${landmark.series ?? 'global'}`"
+                    class="flex flex-row gap-2 max-w-[240px]"
+                  >
+                    <span class="w-6 shrink-0" :class="landmark.icon" />
+
+                    <span>
+                      {{ landmark.name }}:
+                      {{ landmark.description }}
+                    </span>
                   </div>
                 </div>
               </div>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -348,6 +348,7 @@ const visibleLandmarkByIndex = computed(() => {
                       opacity="1"
                     >
                       <title>{{ landmark.name }}</title>
+                      <!-- eslint-disable-next-line vue/no-v-text-v-html-on-component, vue/no-v-html -->
                       <g
                         transform="translate(-7.68, -7.68) scale(0.64)"
                         stroke="currentColor"

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -358,6 +358,7 @@ const visibleLandmarkByIndex = computed(() => {
                         fill="none"
                         v-html="landmark.iconSvg"
                       />
+                      <!-- eslint-enable vue/no-v-text-v-html-on-component, vue/no-v-html -->
                     </g>
                   </g>
                 </template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -7,7 +7,10 @@ import {
 } from 'vue-data-ui/vue-ui-xy'
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { useColors } from '~/composables/useColors'
-import { getClosedPrPercentageEvolutionTotal } from '~~/shared/utils/charts'
+import {
+  getClosedPrPercentageEvolutionTotal,
+  SVG_ICON,
+} from '~~/shared/utils/charts'
 import { identityConfig } from '@unveil/identity'
 import { round } from '~~/shared/utils/numbers'
 
@@ -226,18 +229,22 @@ function getTrend({
 /**
  * Temporary landmark for sample updates
  * We can remove it later if we don't notice any before/after trend shifts
- * The landmark is visible only when it is a week older than the last date of the dataset.
+ * The landmark is visible only when it is a day older than the last date of the dataset.
  */
 const landmarks = [
   {
     date: '2026-07-01',
     name: 'Sample update',
     description: '16 repositories added to the dataset',
+    icon: 'i-lucide:info', // for the tooltip
+    iconSvg: SVG_ICON.info, // for the #svg slot
   },
   {
     date: '2026-07-18',
     name: 'Sample update',
     description: '16 repositories added to the dataset',
+    icon: 'i-lucide:info',
+    iconSvg: SVG_ICON.info,
   },
 ]
 
@@ -341,30 +348,15 @@ const visibleLandmarkByIndex = computed(() => {
                       opacity="1"
                     >
                       <title>{{ landmark.name }}</title>
-                      <g transform="translate(-7.68, -7.68) scale(0.64)">
-                        <circle
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          :stroke="colors.border"
-                          stroke-width="2"
-                          fill="none"
-                        />
-                        <path
-                          d="M12 16v-4"
-                          :stroke="colors.border"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          fill="none"
-                        />
-                        <path
-                          d="M12 8h.01"
-                          :stroke="colors.border"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                          fill="none"
-                        />
-                      </g>
+                      <g
+                        transform="translate(-7.68, -7.68) scale(0.64)"
+                        stroke="currentColor"
+                        stroke-width="2"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        fill="none"
+                        v-html="landmark.iconSvg"
+                      />
                     </g>
                   </g>
                 </template>
@@ -439,7 +431,13 @@ const visibleLandmarkByIndex = computed(() => {
                   class="mt-2 text-xs text-gh-muted"
                 >
                   <div class="flex flex-row gap-2 max-w-[200px]">
-                    <span class="i-lucide:info w-6" />
+                    <span
+                      class="w-6"
+                      :class="
+                        visibleLandmarkByIndex.get(timeLabel.absoluteIndex)
+                          ?.icon
+                      "
+                    />
                     <span
                       >{{
                         visibleLandmarkByIndex.get(timeLabel.absoluteIndex)

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -9,6 +9,7 @@ import {
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { useColors } from '~/composables/useColors'
 import {
+  AUTOMATION_PR_CLOSURE_RATE,
   getClosedPrPercentageEvolutionTotal,
   SVG_ICON,
 } from '~~/shared/utils/charts'
@@ -233,7 +234,7 @@ type Landmark = {
   description: string
   icon: string
   iconSvg: string
-  series?: IdentityClassification
+  series?: IdentityClassification | typeof AUTOMATION_PR_CLOSURE_RATE
   offsetY?: number
 }
 
@@ -333,7 +334,7 @@ function placeLandmark({
   }
 
   const seriesName = landmark.series.toLowerCase()
-  const seriesIndex = rawDataset.value.findIndex(
+  const seriesIndex = dataset.value.findIndex(
     (item) => item.name.toLowerCase() === seriesName,
   )
 

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -9,7 +9,7 @@ import {
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { useColors } from '~/composables/useColors'
 import {
-  AUTOMATION_PR_CLOSURE_RATE,
+  type AUTOMATION_PR_CLOSURE_RATE,
   getClosedPrPercentageEvolutionTotal,
   SVG_ICON,
 } from '~~/shared/utils/charts'

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -4,6 +4,7 @@ import {
   VueUiXy,
   type VueUiXyDatasetItem,
   type VueUiXyConfig,
+  type VueUiXySvgSlotProps,
 } from 'vue-data-ui/vue-ui-xy'
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { useColors } from '~/composables/useColors'
@@ -11,7 +12,7 @@ import {
   getClosedPrPercentageEvolutionTotal,
   SVG_ICON,
 } from '~~/shared/utils/charts'
-import { identityConfig } from '@unveil/identity'
+import { identityConfig, type IdentityClassification } from '@unveil/identity'
 import { round } from '~~/shared/utils/numbers'
 
 import 'vue-data-ui/style.css'
@@ -226,12 +227,22 @@ function getTrend({
   }
 }
 
+type Landmark = {
+  date: string
+  name: string
+  description: string
+  icon: string
+  iconSvg: string
+  series?: IdentityClassification
+  offsetY?: number
+}
+
 /**
  * Temporary landmark for sample updates
  * We can remove it later if we don't notice any before/after trend shifts
  * The landmark is visible only when it is a day older than the last date of the dataset.
  */
-const landmarks = [
+const landmarks: Landmark[] = [
   {
     date: '2026-07-01',
     name: 'Sample update',
@@ -246,6 +257,16 @@ const landmarks = [
     icon: 'i-lucide:info',
     iconSvg: SVG_ICON.info,
   },
+  // Example to place a landmark on a specific series coordinates
+  // {
+  //   date: '2026-07-06',
+  //   name: 'Clank news',
+  //   description: 'Claude is dead',
+  //   icon: 'i-lucide:newspaper',
+  //   iconSvg: SVG_ICON.newspaper,
+  //   series: 'automation',
+  //   offsetY: -16,
+  // },
 ]
 
 const keyDates = computed(() => {
@@ -286,6 +307,43 @@ const visibleLandmarkByIndex = computed(() => {
   })
   return landmarkMap
 })
+
+function placeLandmark({
+  svg,
+  landmark,
+  plotIndex,
+}: {
+  svg: VueUiXySvgSlotProps['svg']
+  landmark: Landmark
+  plotIndex: number
+}): {
+  translate: string // for the landmark group wrapper
+  y: number // can be used for the landmark label
+} {
+  const fallbackY = svg.drawingArea.bottom - 22
+  const x = svg.data?.[0]?.plots?.[plotIndex]?.x ?? 0
+
+  if (!landmark.series) {
+    return {
+      translate: `translate(${x}, ${fallbackY})`,
+      y: fallbackY,
+    }
+  }
+
+  const seriesName = landmark.series.toLowerCase()
+  const seriesIndex = rawDataset.value.findIndex(
+    (item) => item.name.toLowerCase() === seriesName,
+  )
+
+  const y =
+    (svg.data?.[seriesIndex]?.plots?.[plotIndex]?.y ?? fallbackY) +
+    (landmark.offsetY ?? 0)
+
+  return {
+    translate: `translate(${x}, ${y})`,
+    y,
+  }
+}
 </script>
 <template>
   <div class="relative h-full w-full flex flex-col">
@@ -342,7 +400,9 @@ const visibleLandmarkByIndex = computed(() => {
                     </text>
                     <!-- Landmark icon -->
                     <g
-                      :transform="`translate(${plot.x}, ${svg.drawingArea.bottom - 22})`"
+                      :transform="
+                        placeLandmark({ svg, landmark, plotIndex: i }).translate
+                      "
                       class="hidden md:block"
                       style="pointer-events: all; cursor: default"
                       opacity="1"

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -297,6 +297,8 @@ export function getClosedPrPercentageEvolutionByRepo(
   ])
 }
 
+export const AUTOMATION_PR_CLOSURE_RATE = 'Automation PR closure rate' as const
+
 export function getClosedPrPercentageEvolutionTotal(
   source: EcosystemHealthItem[] = [],
   scoreBounds: ScoreBounds = [0, 100],
@@ -324,7 +326,7 @@ export function getClosedPrPercentageEvolutionTotal(
   })
 
   return {
-    name: 'Automation PR closure rate',
+    name: AUTOMATION_PR_CLOSURE_RATE,
     series: series.map((value) => Math.round(value)),
     type: 'line',
     smooth: true,

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -628,3 +628,29 @@ function isLastDatapointLabel(
 ): label is LastDatapointLabel {
   return label !== null
 }
+
+/**
+ * SVG markup fragments based on related Lucide icons.
+ *
+ * Render an icon using `v-html` inside an SVG `<g>` element.
+ * Apply stroke, fill, and transformation attributes to the `<g>` element.
+ *
+ * @example
+ * ```vue
+ * <g
+ *   transform="translate(-7.68, -7.68) scale(0.64)"
+ *   stroke="currentColor"
+ *   stroke-width="2"
+ *   stroke-linecap="round"
+ *   stroke-linejoin="round"
+ *   fill="none"
+ *   v-html="landmark.iconSvg"
+ * />
+ * ```
+ * To extend the list of icons, add the lucide icon key, copy the svg from lucide website, and only keep the SVG elements (not the wrapping <svg> tag basically)
+ *
+ */
+export const SVG_ICON = {
+  info: `<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>`,
+  newspaper: `<path d="M15 18h-5"/><path d="M18 14h-8"/><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"/><rect stroke="currentColor" width="8" height="4" x="10" y="6" rx="1"/>`,
+}


### PR DESCRIPTION
This improves the landmark system for the health chart, allowing diverse icons to be used, in the perspective of showing important news from the clanker world, that could possibly explain a trend.

The previous system improves the icon injected in the #svg slot, by using the exact svg fragments from the lucide icon library, which I placed in a constant in the charts util.

https://github.com/user-attachments/assets/1d4c0441-e9d9-4571-b0d4-fed0d830cc3a

NOTE: there is a use case that is not taken care of for now; when multiple landmarks are on the same date. If it ever happens, we'll have to stack them in some way, or just have 1 info icon in the chart, and have only the tooltip with all the details. But I don't think it will happen soon, so dealing with this now would be premature.

EDIT: the following features are also added:
- optionally place landmarks on specific series
- tooltip supports multiple landmarks at the same date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Chart landmarks now display context-specific SVG icons within the visualization and the “LANDMARK INFO” tooltip.
  * Added support for additional landmark icon styles (information and newspaper).

* **Bug Fixes**
  * Updated landmark messaging to correctly reference “days older” relative to the last available date.
  * Improved landmark placement to ensure icons and landmark groups render at the correct chart position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->