### PR TITLE
feat: health chart thinner stroke-width on mobile

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -17,6 +17,7 @@ import { identityConfig, type IdentityClassification } from '@unveil/identity'
 import { round } from '~~/shared/utils/numbers'
 
 import 'vue-data-ui/style.css'
+import { useIsMobile } from '~/composables/useIsMobile'
 const { data: ecosystemHealth } = await useEcosystemHealth()
 const data = computed(() => ecosystemHealth.value?.results ?? [])
 const dates = computed(() => ecosystemHealth.value?.dates)
@@ -24,6 +25,7 @@ const countsByDate = computed(() => ecosystemHealth.value?.countsByDate)
 
 const chartContainer = useTemplateRef<HTMLElement>('chartContainer')
 const { width, height } = useElementSize(chartContainer)
+const isMobile = useIsMobile()
 
 const hasStableChartDimensions = computed(
   () => width.value > 0 && height.value > 0,
@@ -148,6 +150,7 @@ const config = computed<VueUiXyConfig>(() => ({
     threshold: 5000,
   },
   line: {
+    strokeWidth: isMobile.value ? 1 : 3,
     radius: 0,
     useGradient: false,
     dot: {

--- a/app/composables/useIsMobile.ts
+++ b/app/composables/useIsMobile.ts
@@ -1,0 +1,11 @@
+import { useMediaQuery } from '@vueuse/core'
+
+/**
+ * Composable for detecting mobile devices using media query.
+ * Uses the same breakpoint as Tailwind's `md:` (768px).
+ *
+ * Returns `false` during SSR to avoid hydration mismatches.
+ */
+export function useIsMobile() {
+  return useMediaQuery('(max-width: 767px)')
+}


### PR DESCRIPTION
This is a small improvement for the health chart on mobile, where in my opinion, the stroke width of the lines are too thick.

- thinner on mobile = better readability, more elegant (imo^^)
- added a `useIsMobile` composable I stole from npmx

| BEFORE | AFTER |
|-|-|
|<img width="300" alt="image" src="https://github.com/user-attachments/assets/f7dcaa5b-0252-4a73-83a8-7a844734a9ad" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/87490228-113e-45ad-a84f-63168826185e" />|