### PR TITLE
feat(gh-app): add details on comment

### DIFF
--- a/app/components/Analysis/Card.vue
+++ b/app/components/Analysis/Card.vue
@@ -4,6 +4,7 @@ import type {
   IdentityClassification,
   IdentifyResult,
 } from '@unveil/identity'
+import { buildReportIssueUrl } from '~~/shared/utils/report-issue'
 
 const props = defineProps<{
   user: GitHubUser
@@ -71,14 +72,14 @@ const classificationIcon = computed<string>(() => {
 })
 
 const flagAccountUrl = computed<string>(() => {
-  const baseUrl = 'https://github.com/MatteoGabriele/agentscan/issues/new'
-  const params = new URLSearchParams({
-    template: 'report-automated-account.yml',
-    title: `[AUTOMATION] ${username.value}`,
+  return buildReportIssueUrl({
     username: username.value || '',
-    'user-id': props.user.id.toString(),
+    userId: props.user.id,
+    classification: classification.value ?? 'organic',
+    score: score.value ?? 0,
+    flags: data.value?.analysis.flags ?? [],
+    sourceUrl: `https://agentscan.tools/user/${username.value}`,
   })
-  return `${baseUrl}?${params.toString()}`
 })
 
 const identifyAnalysis = computed<IdentifyResult | undefined>(() => {

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -13,6 +13,10 @@ import {
   type AuthorAssociation,
   type RepoConfig,
 } from './_config'
+import {
+  buildEvidenceLines,
+  buildReportIssueUrl,
+} from '~~/shared/utils/report-issue'
 
 type AutomationListItem = {
   username: string
@@ -222,6 +226,7 @@ export default defineEventHandler(async (event) => {
     }
 
     const hasCommunityFlag = verified.some((a) => a.username === username)
+    const userId: number | undefined = user.id
 
     const analysis: IdentifyResult = identify({
       accountName: username,
@@ -313,6 +318,30 @@ export default defineEventHandler(async (event) => {
 
     const MARKER = '<!-- agentscanapp-bot -->'
 
+    const sourceUrl: string =
+      payload.pull_request?.html_url ??
+      payload.issue?.html_url ??
+      `https://github.com/${owner}/${repo}/${isPR ? 'pull' : 'issues'}/${targetNumber}`
+
+    const reportUrl =
+      analysis.classification === 'automation' && !hasCommunityFlag
+        ? buildReportIssueUrl({
+            username,
+            userId,
+            classification: analysis.classification,
+            score: analysis.score,
+            flags: analysis.flags,
+            sourceUrl,
+          })
+        : null
+
+    // Rendered inline (no sourceUrl - pointing back at the PR/issue it's already on is redundant)
+    // so a reviewer can see the evidence without leaving this page.
+    const evidenceLines =
+      analysis.flags.length > 0
+        ? buildEvidenceLines({ flags: analysis.flags })
+        : []
+
     const body = [
       MARKER,
       `### ${indicator} ${details.label}`,
@@ -320,6 +349,18 @@ export default defineEventHandler(async (event) => {
       description,
       '',
       `[View full analysis →](https://agentscan.tools/user/${username})`,
+      ...(reportUrl ? ['', `[🚩 Report this account →](${reportUrl})`] : []),
+      ...(evidenceLines.length > 0
+        ? [
+            '',
+            '<details>',
+            '<summary>Evidence</summary>',
+            '',
+            ...evidenceLines,
+            '',
+            '</details>',
+          ]
+        : []),
       '',
       '<sub>This is an automated analysis by [AgentScan](https://agentscan.tools)</sub>',
     ].join('\n')

--- a/shared/utils/report-issue.ts
+++ b/shared/utils/report-issue.ts
@@ -1,0 +1,146 @@
+import type { IdentifyFlag } from '@unveil/identity'
+
+const REPORT_ISSUE_URL =
+  'https://github.com/matteogabriele/agentscan/issues/new'
+const MAX_EVIDENCE_FLAGS = 8
+const MAX_EXAMPLE_PRS = 5
+
+type ReportIssueParams = {
+  username: string
+  userId: number | undefined
+  classification: string
+  score: number
+  flags: IdentifyFlag[]
+  sourceUrl: string
+}
+
+type EvidenceParams = {
+  flags: IdentifyFlag[]
+  sourceUrl?: string
+}
+
+/**
+ * A github.com link to a PR/issue in the evidence body would make GitHub post an
+ * unwanted "mentioned this pull request" backlink on that PR once the report issue
+ * is filed. redirect.github.com is GitHub's documented escape hatch: it 302s to the
+ * same page but isn't recognized by the reference parser, so no backlink is created.
+ * https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls
+ */
+function withoutBacklink(url: string): string {
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname === 'github.com') {
+      parsed.hostname = 'redirect.github.com'
+    }
+    return parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+/**
+ * Flags carry the raw GitHub events that triggered them. Pull a handful of the
+ * actual PRs behind a "PR volume"/"fork→PR pattern" style flag so a reviewer has
+ * concrete examples to look at, instead of just the aggregate detail string.
+ */
+function extractExamplePrUrls(flags: IdentifyFlag[], limit: number): string[] {
+  const urls = new Set<string>()
+
+  for (const flag of flags) {
+    for (const event of flag.events ?? []) {
+      if (urls.size >= limit) {
+        break
+      }
+      if (event.type !== 'PullRequestEvent') {
+        continue
+      }
+
+      const pr = event.payload?.pull_request as
+        | { html_url?: string; number?: number }
+        | undefined
+      const url =
+        pr?.html_url ??
+        (event.repo?.name && pr?.number !== undefined
+          ? `https://github.com/${event.repo.name}/pull/${pr.number}`
+          : undefined)
+
+      if (url) {
+        urls.add(url)
+      }
+    }
+  }
+
+  return [...urls].slice(0, limit)
+}
+
+/**
+ * Builds the evidence lines shared between the PR/issue comment and the pre-filled
+ * report-issue link, so both surfaces always show the same facts.
+ */
+export function buildEvidenceLines({
+  flags,
+  sourceUrl,
+}: EvidenceParams): string[] {
+  const topFlags = [...flags]
+    .sort((a, b) => b.points - a.points)
+    .slice(0, MAX_EVIDENCE_FLAGS)
+
+  const examplePrUrls = extractExamplePrUrls(flags, MAX_EXAMPLE_PRS)
+
+  const lines: string[] = []
+
+  if (sourceUrl) {
+    lines.push(`- Flagged in: ${withoutBacklink(sourceUrl)}`)
+  }
+
+  lines.push(...topFlags.map((flag) => `- ${flag.label}: ${flag.detail}`))
+
+  if (flags.length > topFlags.length) {
+    lines.push(
+      `- (+${flags.length - topFlags.length} more signal(s), see full analysis)`,
+    )
+  }
+
+  if (examplePrUrls.length > 0) {
+    lines.push(
+      '',
+      `Last ${examplePrUrls.length} PR${examplePrUrls.length === 1 ? '' : 's'}:`,
+      ...examplePrUrls.map((url) => `- ${withoutBacklink(url)}`),
+    )
+  }
+
+  return lines
+}
+
+/**
+ * Builds a pre-filled "Report Automated Account" issue URL from an already-computed
+ * analysis, so a maintainer only has to review and submit it instead of retyping
+ * evidence AgentScan already has. Shared between the GitHub webhook comment and the
+ * "Add report" link on the analysis page, so both point at the same rich report.
+ */
+export function buildReportIssueUrl({
+  username,
+  userId,
+  classification,
+  score,
+  flags,
+  sourceUrl,
+}: ReportIssueParams): string {
+  const reason = `AgentScan classified this account as possible "${classification}" (score ${score}/100).`
+
+  const evidenceLines = buildEvidenceLines({ flags, sourceUrl })
+
+  const url = new URL(REPORT_ISSUE_URL)
+  url.searchParams.set('template', 'report-automated-account.yml')
+  url.searchParams.set('title', `[AUTOMATION] ${username}`)
+  url.searchParams.set('username', username)
+
+  if (userId !== undefined) {
+    url.searchParams.set('user-id', String(userId))
+  }
+
+  url.searchParams.set('reason', reason)
+  url.searchParams.set('evidence', evidenceLines.join('\n'))
+
+  return url.toString()
+}

--- a/test/unit/server/api/webhook/github.post.test.ts
+++ b/test/unit/server/api/webhook/github.post.test.ts
@@ -900,6 +900,93 @@ describe('GitHub Webhook Handler', () => {
     })
   })
 
+  describe('Report Link', () => {
+    it('includes a pre-filled report-issue link for automation classifications', async () => {
+      vi.mocked(identify).mockReturnValue({
+        ...MOCK_ANALYSIS,
+        classification: 'automation',
+      })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall =
+        mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).toContain('[🚩 Report this account →]')
+      expect(commentCall.body).toContain(
+        'https://github.com/matteogabriele/agentscan/issues/new',
+      )
+      expect(commentCall.body).toContain('username=test-user')
+    })
+
+    it('omits the report link for mixed classifications', async () => {
+      vi.mocked(identify).mockReturnValue({
+        ...MOCK_ANALYSIS,
+        classification: 'mixed',
+      })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall =
+        mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).not.toContain('Report this account')
+    })
+
+    it('omits the report link for organic classifications', async () => {
+      mockRepoConfig({ 'comment-on-organic': true })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall =
+        mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).not.toContain('Report this account')
+    })
+
+    it('omits the report link for community-flagged accounts even when classification is automation', async () => {
+      vi.mocked(identify).mockReturnValue({
+        ...MOCK_ANALYSIS,
+        classification: 'automation',
+      })
+      mockVerifiedList(['test-user'])
+
+      await handler(MOCK_EVENT)
+
+      const commentCall =
+        mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).not.toContain('Report this account')
+    })
+  })
+
+  describe('Evidence', () => {
+    it('includes a collapsible evidence section listing the flags', async () => {
+      vi.mocked(identify).mockReturnValue({
+        ...MOCK_ANALYSIS,
+        classification: 'automation',
+      })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall =
+        mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).toContain('<details>')
+      expect(commentCall.body).toContain('<summary>Evidence</summary>')
+      expect(commentCall.body).toContain('Test Flag: Test detail')
+    })
+
+    it('omits the evidence section when there are no flags', async () => {
+      vi.mocked(identify).mockReturnValue({
+        ...MOCK_ANALYSIS,
+        classification: 'automation',
+        flags: [],
+      })
+
+      await handler(MOCK_EVENT)
+
+      const commentCall =
+        mockInstallationOctokit.rest.issues.createComment.mock.calls[0][0]
+      expect(commentCall.body).not.toContain('<details>')
+    })
+  })
+
   describe('GitHub Checks', () => {
     it('creates an in-progress check run on the PR head SHA before scanning', async () => {
       await handler(MOCK_EVENT)

--- a/test/unit/shared/utils/report-issue.test.ts
+++ b/test/unit/shared/utils/report-issue.test.ts
@@ -1,0 +1,286 @@
+import type { GitHubEvent, IdentifyFlag } from '@unveil/identity'
+import { describe, expect, it } from 'vitest'
+import {
+  buildEvidenceLines,
+  buildReportIssueUrl,
+} from '../../../../shared/utils/report-issue'
+
+const makeFlag = (overrides: Partial<IdentifyFlag> = {}): IdentifyFlag => ({
+  label: 'Test Flag',
+  points: 10,
+  detail: 'Test detail',
+  data: [],
+  events: [],
+  ...overrides,
+})
+
+const makePrEvent = (
+  repoName: string,
+  number: number,
+  htmlUrl?: string,
+): GitHubEvent =>
+  ({
+    type: 'PullRequestEvent',
+    repo: { name: repoName },
+    payload: {
+      pull_request: {
+        number,
+        ...(htmlUrl ? { html_url: htmlUrl } : {}),
+      },
+    },
+  }) as unknown as GitHubEvent
+
+describe('buildReportIssueUrl', () => {
+  it('points at the report-automated-account issue template on the real agentscan repo', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [makeFlag()],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    expect(url.origin + url.pathname).toBe(
+      'https://github.com/matteogabriele/agentscan/issues/new',
+    )
+    expect(url.searchParams.get('template')).toBe(
+      'report-automated-account.yml',
+    )
+    expect(url.searchParams.get('title')).toBe('[AUTOMATION] bot-account')
+    expect(url.searchParams.get('username')).toBe('bot-account')
+    expect(url.searchParams.get('user-id')).toBe('123')
+  })
+
+  it('omits user-id when it is unknown', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: undefined,
+        classification: 'automation',
+        score: 5,
+        flags: [makeFlag()],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    expect(url.searchParams.has('user-id')).toBe(false)
+  })
+
+  it('reports the reason with classification, score, and flag count', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [makeFlag(), makeFlag()],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    expect(url.searchParams.get('reason')).toBe(
+      'AgentScan classified this account as possible "automation" (score 5/100).',
+    )
+  })
+
+  it('includes the source link plus each flag label and detail in the evidence', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [
+          makeFlag({
+            label: 'Fork surge',
+            detail: '12 forks in 24h',
+            points: 51,
+          }),
+          makeFlag({
+            label: 'PR burst',
+            detail: '20 PRs in a day',
+            points: 45,
+          }),
+        ],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    expect(evidence).toContain('https://redirect.github.com/owner/repo/pull/1')
+    expect(evidence).toContain('Fork surge: 12 forks in 24h')
+    expect(evidence).toContain('PR burst: 20 PRs in a day')
+  })
+
+  it('rewrites the source github.com link to redirect.github.com to avoid an unwanted backlink on the flagged PR', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [makeFlag()],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    expect(evidence).not.toContain('https://github.com/')
+    expect(evidence).toContain('https://redirect.github.com/owner/repo/pull/1')
+  })
+
+  it('leaves non-github.com source URLs untouched', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [makeFlag()],
+        sourceUrl: 'https://gitlab.example.com/owner/repo/-/merge_requests/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    expect(evidence).toContain(
+      'https://gitlab.example.com/owner/repo/-/merge_requests/1',
+    )
+  })
+
+  it('caps the evidence list to the highest-scoring flags and notes the remainder', () => {
+    const flags = Array.from({ length: 10 }, (_, index) =>
+      makeFlag({
+        label: `Flag ${index}`,
+        detail: `Detail ${index}`,
+        points: index,
+      }),
+    )
+
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags,
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    // Highest-points flags (9 down to 2) should be included...
+    expect(evidence).toContain('Flag 9: Detail 9')
+    expect(evidence).toContain('Flag 2: Detail 2')
+    // ...lowest-points flags should be dropped, with a note on how many.
+    expect(evidence).not.toContain('Flag 0: Detail 0')
+    expect(evidence).not.toContain('Flag 1: Detail 1')
+    expect(evidence).toContain('+2 more signal(s)')
+  })
+
+  it('lists example PRs derived from the flags underlying events, rewritten to avoid backlinks', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [
+          makeFlag({
+            events: [
+              makePrEvent(
+                'owner/repo1',
+                10,
+                'https://github.com/owner/repo1/pull/10',
+              ),
+              // No html_url on the raw event: falls back to repo + number.
+              makePrEvent('owner/repo2', 20),
+            ],
+          }),
+        ],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    expect(evidence).toContain('Last 2 PRs:')
+    expect(evidence).toContain(
+      'https://redirect.github.com/owner/repo1/pull/10',
+    )
+    expect(evidence).toContain(
+      'https://redirect.github.com/owner/repo2/pull/20',
+    )
+  })
+
+  it('dedupes example PRs across flags and caps the list at 5', () => {
+    const events = Array.from({ length: 4 }, (_, index) =>
+      makePrEvent(`owner/repo${index + 1}`, index + 1),
+    )
+    const duplicateEvent = makePrEvent('owner/repo1', 1)
+
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [
+          makeFlag({ events }),
+          makeFlag({
+            events: [
+              duplicateEvent,
+              makePrEvent('owner/repo5', 5),
+              makePrEvent('owner/repo6', 6),
+            ],
+          }),
+        ],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    expect(evidence).toContain('Last 5 PRs:')
+    const prLines = evidence
+      .split('\n')
+      .filter((line) => line.startsWith('- https://redirect.github.com'))
+    expect(prLines).toHaveLength(5)
+    expect(evidence).not.toContain('owner/repo6')
+  })
+
+  it('omits the example PRs section when flags carry no PR events', () => {
+    const url = new URL(
+      buildReportIssueUrl({
+        username: 'bot-account',
+        userId: 123,
+        classification: 'automation',
+        score: 5,
+        flags: [makeFlag({ events: [] })],
+        sourceUrl: 'https://github.com/owner/repo/pull/1',
+      }),
+    )
+
+    const evidence = url.searchParams.get('evidence') ?? ''
+    expect(evidence).not.toContain('PRs:')
+  })
+})
+
+describe('buildEvidenceLines', () => {
+  it('omits the "Flagged in" line when no sourceUrl is given', () => {
+    const lines = buildEvidenceLines({ flags: [makeFlag()] })
+
+    expect(lines.some((line) => line.startsWith('- Flagged in:'))).toBe(false)
+  })
+
+  it('includes the "Flagged in" line, rewritten to avoid a backlink, when sourceUrl is given', () => {
+    const lines = buildEvidenceLines({
+      flags: [makeFlag()],
+      sourceUrl: 'https://github.com/owner/repo/pull/1',
+    })
+
+    expect(lines[0]).toBe(
+      '- Flagged in: https://redirect.github.com/owner/repo/pull/1',
+    )
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-filled “Report this account” link for accounts classified as automation.
  * Added detailed evidence to analysis reports, including key signals, source links, and example pull requests.
  * Added collapsible evidence sections to GitHub analysis comments.
  * Report links are omitted for organic, mixed, or community-flagged accounts.

* **Bug Fixes**
  * Improved report links and evidence formatting for clearer, more consistent reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->