### PR TITLE
feat(health): add daily scan time

### DIFF
--- a/app/composables/useNextScanTime.ts
+++ b/app/composables/useNextScanTime.ts
@@ -1,140 +1,60 @@
+import type { Dayjs } from 'dayjs'
 import dayjs from 'dayjs'
-import utc from 'dayjs/plugin/utc'
+import utc from 'dayjs/plugin/utc.js'
 
 dayjs.extend(utc)
 
-// Replica of the cron schedules in .github/workflows/scan-users.yml
-const SCAN_SCHEDULE: Record<number, { hour: number; minute: number }> = {
-  1: { hour: 0, minute: 0 },
-  2: { hour: 3, minute: 26 },
-  3: { hour: 6, minute: 51 },
-  4: { hour: 10, minute: 17 },
-  5: { hour: 13, minute: 43 },
-  6: { hour: 17, minute: 9 },
-  7: { hour: 20, minute: 34 },
-  8: { hour: 0, minute: 0 },
-  9: { hour: 3, minute: 26 },
-  10: { hour: 6, minute: 51 },
-  11: { hour: 10, minute: 17 },
-  12: { hour: 13, minute: 43 },
-  13: { hour: 17, minute: 9 },
-  14: { hour: 20, minute: 34 },
-  15: { hour: 0, minute: 0 },
-  16: { hour: 3, minute: 26 },
-  17: { hour: 6, minute: 51 },
-  18: { hour: 10, minute: 17 },
-  19: { hour: 13, minute: 43 },
-  20: { hour: 17, minute: 9 },
-  21: { hour: 20, minute: 34 },
-  22: { hour: 0, minute: 0 },
-  23: { hour: 3, minute: 26 },
-  24: { hour: 6, minute: 51 },
-  25: { hour: 10, minute: 17 },
-  26: { hour: 13, minute: 43 },
-  27: { hour: 17, minute: 9 },
-  28: { hour: 20, minute: 34 },
-  29: { hour: 0, minute: 0 },
-  30: { hour: 3, minute: 26 },
-  31: { hour: 6, minute: 51 },
+// Replica of the cron schedules in .github/workflows/scan-users.yml, which
+// rotate on a 7-day cycle keyed off the day of the month.
+const workflowScheduler = [
+  { hour: 0, minute: 0 },
+  { hour: 3, minute: 26 },
+  { hour: 6, minute: 51 },
+  { hour: 10, minute: 17 },
+  { hour: 13, minute: 43 },
+  { hour: 17, minute: 9 },
+  { hour: 20, minute: 34 },
+]
+
+function scanTimeOn(date: Dayjs): Dayjs | undefined {
+  const dateIndex: number = (date.date() - 1) % 7
+  const currentSchedule = workflowScheduler[dateIndex]
+
+  if (!currentSchedule) {
+    return
+  }
+
+  const { hour, minute } = currentSchedule
+  return date.hour(hour).minute(minute).second(0).millisecond(0)
 }
 
-// Buffer to account for GitHub workflow delays + scan time
-const SCAN_TIME_BUFFER_MINUTES = 30
+type UseNextScanTimeReturn = {
+  nextScanTime: ComputedRef<string | undefined>
+}
 
-function getNextScanTime(currentDate: Date = new Date()): Date {
-  const now = dayjs.utc(currentDate)
-  const currentDay = now.date()
+export function useNextScanTime(): UseNextScanTimeReturn {
+  const nextScanTime = computed<string | undefined>(() => {
+    const now = dayjs.utc()
+    const today = scanTimeOn(now)
 
-  const todaySchedule = SCAN_SCHEDULE[currentDay]
-  if (todaySchedule) {
-    const scanTimeToday = now
-      .hour(todaySchedule.hour)
-      .minute(todaySchedule.minute)
-      .second(0)
-      .millisecond(0)
-      .add(SCAN_TIME_BUFFER_MINUTES, 'minute')
-
-    if (scanTimeToday.isAfter(now)) {
-      return scanTimeToday.toDate()
+    if (!today) {
+      return
     }
-  }
 
-  let nextDay = currentDay + 1
-  const daysInMonth = now.daysInMonth()
-  let nextDate
+    const nextScan = today.isAfter(now) ? today : scanTimeOn(now.add(1, 'day'))
 
-  if (nextDay > daysInMonth) {
-    nextDay = 1
-    nextDate = now.add(1, 'month').date(1)
-  } else {
-    nextDate = now.add(1, 'day')
-  }
+    const local = nextScan?.local()
 
-  const nextSchedule = SCAN_SCHEDULE[nextDay]!
-  const nextScanDate = nextDate
-    .hour(nextSchedule.hour)
-    .minute(nextSchedule.minute)
-    .second(0)
-    .millisecond(0)
-    .add(SCAN_TIME_BUFFER_MINUTES, 'minute')
-
-  return nextScanDate.toDate()
-}
-
-function formatNextScanTime(nextScanDate: Date): string {
-  const now = dayjs.utc()
-  const scanTime = dayjs.utc(nextScanDate)
-
-  const diffMs = scanTime.diff(now)
-
-  if (diffMs < 0) {
-    return 'Scan in progress'
-  }
-
-  const diffDays = scanTime.diff(now, 'day')
-  const diffHours = scanTime.diff(now, 'hour')
-  const diffMinutes = scanTime.diff(now, 'minute')
-
-  if (diffHours === 0) {
-    return `Next scan in ${diffMinutes} minute${diffMinutes !== 1 ? 's' : ''}`
-  }
-
-  if (diffDays === 0) {
-    const remainingMinutes = diffMinutes % 60
-    return `Next scan in ${diffHours} hour${diffHours !== 1 ? 's' : ''} and ${remainingMinutes} minute${remainingMinutes !== 1 ? 's' : ''}`
-  }
-
-  const scanTimeUtc = scanTime.format('HH:mm')
-  return `Next scan in ${diffDays} day${diffDays !== 1 ? 's' : ''} at ${scanTimeUtc} UTC`
-}
-
-export function useNextScanTime() {
-  const now = ref(new Date())
-  let intervalId: ReturnType<typeof setInterval> | null = null
-
-  const nextScanTime = computed(() => {
-    return getNextScanTime(now.value)
-  })
-
-  const formattedNextScanTime = computed(() => {
-    return formatNextScanTime(nextScanTime.value)
-  })
-
-  onMounted(() => {
-    // Update every minute to keep the display fresh
-    intervalId = setInterval(() => {
-      now.value = new Date()
-    }, 60000)
-  })
-
-  onBeforeUnmount(() => {
-    if (intervalId) {
-      clearInterval(intervalId)
+    if (!local) {
+      return
     }
+
+    const day = local.isSame(dayjs(), 'day') ? 'today' : 'tomorrow'
+
+    return `Next scan ${day} at ${local.format('HH:mm')}`
   })
 
   return {
     nextScanTime,
-    formattedNextScanTime,
   }
 }

--- a/app/composables/useNextScanTime.ts
+++ b/app/composables/useNextScanTime.ts
@@ -33,25 +33,53 @@ type UseNextScanTimeReturn = {
 }
 
 export function useNextScanTime(): UseNextScanTimeReturn {
-  const nextScanTime = computed<string | undefined>(() => {
-    const now = dayjs.utc()
-    const today = scanTimeOn(now)
+  const now = ref(dayjs.utc())
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  const nextScan = computed<Dayjs | undefined>(() => {
+    const today = scanTimeOn(now.value)
 
     if (!today) {
       return
     }
 
-    const nextScan = today.isAfter(now) ? today : scanTimeOn(now.add(1, 'day'))
+    return today.isAfter(now.value)
+      ? today
+      : scanTimeOn(now.value.add(1, 'day'))
+  })
 
-    const local = nextScan?.local()
+  const nextScanTime = computed<string | undefined>(() => {
+    const local = nextScan.value?.local()
 
     if (!local) {
       return
     }
 
-    const day = local.isSame(dayjs(), 'day') ? 'today' : 'tomorrow'
+    const day = local.isSame(now.value.local(), 'day') ? 'today' : 'tomorrow'
 
     return `Next scan ${day} at ${local.format('HH:mm')}`
+  })
+
+  function scheduleRefresh() {
+    const target = nextScan.value
+
+    if (!target) {
+      return
+    }
+
+    timeoutId = setTimeout(
+      () => {
+        now.value = dayjs.utc()
+        scheduleRefresh()
+      },
+      Math.max(target.diff(dayjs.utc()) + 1000, 1000),
+    )
+  }
+
+  onMounted(scheduleRefresh)
+
+  onBeforeUnmount(() => {
+    clearTimeout(timeoutId)
   })
 
   return {

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -3,6 +3,8 @@ definePageMeta({
   layout: 'full',
 })
 
+const { nextScanTime } = useNextScanTime()
+
 useHead({
   title: 'GitHub Ecosystem Health | AgentScan',
   meta: [
@@ -46,6 +48,11 @@ useHead({
                 list of repositories
               </NuxtLink>
             </p>
+            <ClientOnly>
+              <p class="text-xs text-gh-muted/70 mt-1 text-pretty">
+                {{ nextScanTime }}
+              </p>
+            </ClientOnly>
           </div>
         </header>
 


### PR DESCRIPTION
Add back the time of the daily scan to fix @graphieros addition to graphs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dynamic next scan time display to the Health page.
  * Scan times are shown in local time with clear “today” or “tomorrow” labels.

* **Bug Fixes**
  * Improved consistency of scheduled scan time calculations.
  * Prevented scan time content from being rendered before client-side data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->