### PR TITLE
feat: add PR count in featured repos closure rate sparklines

### DIFF
--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -781,7 +781,7 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
                 </div>
                 <div class="flex flex-col gap-1.5">
                   <div
-                    v-for="(row, i) in getTooltipRows(timeLabel)"
+                    v-for="row in getTooltipRows(timeLabel)"
                     :key="row.key"
                     class="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2"
                   >

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -9,6 +9,7 @@ import {
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { identityConfig } from '@unveil/identity'
 import { usePreferredDark } from '@vueuse/core'
+import { SERIES } from '~~/shared/utils/charts'
 
 import('vue-data-ui/style.css')
 
@@ -370,13 +371,15 @@ const selectedRawSparklines = computed<SparklineChart[]>(() => {
 
 const sparklines = computed<SparklineChart[]>(() => {
   return selectedRawSparklines.value.map((dataset) => {
-    return dataset.map((datapoint) => ({
-      ...datapoint,
-      color: selectedRangeColor.value,
-      dataLabels: false,
-      suffix: '%',
-      smooth: true,
-    }))
+    return dataset.map((datapoint) => {
+      const isCount = datapoint.name === SERIES.PR_COUNT
+      return {
+        ...datapoint,
+        color: isCount ? colors.value.textMuted : selectedRangeColor.value,
+        dataLabels: false,
+        suffix: isCount ? '' : '%',
+      }
+    })
   })
 })
 
@@ -420,6 +423,7 @@ const config = computed<VueUiXyConfig>(() => ({
         yAxis: {
           scaleMin: 0,
           scaleMax: 100,
+          useIndividualScale: true,
         },
         xAxisLabels: {
           show: false,
@@ -443,6 +447,7 @@ const config = computed<VueUiXyConfig>(() => ({
   line: {
     radius: 0,
     useGradient: false,
+    strokeWidth: 1.5,
     dot: {
       useSerieColor: true,
       fill: selectedRangeColor.value,
@@ -464,8 +469,10 @@ function drawLastDatapointLabel(svg: VueUiXySvgSlotProps['svg']) {
       background: colors.value.bg!,
       fallbackSerieColor: colors.value.textMuted!,
     },
-    formatValue: (value) =>
-      Number.isFinite(value) ? `${value.toFixed(0)}%` : '-',
+    formatValue: (value, serie) =>
+      Number.isFinite(value)
+        ? `${value.toFixed(0)}${serie.name === SERIES.PR_COUNT ? '' : '%'}`
+        : '-',
     isDarkMode: isDarkMode.value,
   })
 }
@@ -503,6 +510,8 @@ type TooltipRow = {
   color: string
   value: string
   detail: string
+  eligiblePrCount: number
+  label: string
 }
 
 function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
@@ -526,14 +535,25 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
           ? 100
           : Math.round((closed / eligible) * 100)
 
+    const isCount = datapoint.name === SERIES.PR_COUNT
+
     return {
       key: repoName,
       owner: owner!,
       repo,
-      color: selectedRangeColor.value ?? 'currentColor',
-      value: Number.isFinite(percentage) ? `${percentage.toFixed(0)}%` : '-',
-      detail:
-        closed == null || eligible == null
+      color: isCount
+        ? (datapoint?.color ?? '#666666')
+        : (selectedRangeColor.value ?? 'currentColor'),
+      eligiblePrCount: eligible ?? 0,
+      label: isCount ? datapoint.name : 'Closure rate',
+      value: isCount
+        ? String(eligible ?? 0)
+        : Number.isFinite(percentage)
+          ? `${percentage.toFixed(0)}%`
+          : '-',
+      detail: isCount
+        ? ''
+        : closed == null || eligible == null
           ? 'No data'
           : `${closed} / ${eligible}`,
     }
@@ -728,16 +748,40 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
               </g>
             </template>
 
+            <template #legend="{ legend }">
+              <div class="flex flex-row gap-4 justify-center mt-2">
+                <button
+                  v-for="item in legend"
+                  :key="item.id"
+                  class="flex flex-row gap-1.5 place-items-center"
+                  :class="item.isSegregated ? 'opacity-50' : 'hover:underline'"
+                  @click="item.segregate()"
+                >
+                  <div class="w-4 h-4">
+                    <svg viewBox="0 0 2 2" class="w-full h-full">
+                      <circle :cx="1" :cy="1" :r="1" :fill="item.color" />
+                    </svg>
+                  </div>
+                  <div
+                    :class="`text-gh-muted text-sm ${item.isSegregated ? 'line-through' : ''}`"
+                  >
+                    {{
+                      item?.independant ? SERIES.PR_COUNT : SERIES.CLOSURE_RATE
+                    }}
+                  </div>
+                </button>
+              </div>
+            </template>
+
             <!-- CUSTOM TOOLTIP -->
-            <template #tooltip="{ timeLabel }">
+            <template #tooltip="{ timeLabel, datapoint }">
               <div class="min-w-[220px] text-xs">
                 <div class="mb-2 font-medium text-gh-muted">
-                  {{ timeLabel.text }}
+                  {{ timeLabel.text }} - {{ datapoint[0]?.name }}
                 </div>
-
                 <div class="flex flex-col gap-1.5">
                   <div
-                    v-for="row in getTooltipRows(timeLabel)"
+                    v-for="(row, i) in getTooltipRows(timeLabel)"
                     :key="row.key"
                     class="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2"
                   >
@@ -747,8 +791,7 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
                       aria-hidden="true"
                     />
                     <span class="min-w-0 truncate text-left">
-                      <span class="text-gh-muted"> {{ row.owner }}/ </span>
-                      <span>{{ row.repo }}</span>
+                      <span>{{ row.label }}</span>
                     </span>
                     <span class="text-gh-muted tabular-nums">
                       {{ row.detail }}

--- a/app/components/Chart/HealthResponseSparklines.vue
+++ b/app/components/Chart/HealthResponseSparklines.vue
@@ -9,7 +9,6 @@ import {
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { identityConfig } from '@unveil/identity'
 import { usePreferredDark } from '@vueuse/core'
-import { SERIES } from '~~/shared/utils/charts'
 
 import('vue-data-ui/style.css')
 
@@ -371,15 +370,13 @@ const selectedRawSparklines = computed<SparklineChart[]>(() => {
 
 const sparklines = computed<SparklineChart[]>(() => {
   return selectedRawSparklines.value.map((dataset) => {
-    return dataset.map((datapoint) => {
-      const isCount = datapoint.name === SERIES.PR_COUNT
-      return {
-        ...datapoint,
-        color: isCount ? colors.value.textMuted : selectedRangeColor.value,
-        dataLabels: false,
-        suffix: isCount ? '' : '%',
-      }
-    })
+    return dataset.map((datapoint) => ({
+      ...datapoint,
+      color: selectedRangeColor.value,
+      dataLabels: false,
+      suffix: '%',
+      smooth: true,
+    }))
   })
 })
 
@@ -423,7 +420,6 @@ const config = computed<VueUiXyConfig>(() => ({
         yAxis: {
           scaleMin: 0,
           scaleMax: 100,
-          useIndividualScale: true,
         },
         xAxisLabels: {
           show: false,
@@ -447,7 +443,6 @@ const config = computed<VueUiXyConfig>(() => ({
   line: {
     radius: 0,
     useGradient: false,
-    strokeWidth: 1.5,
     dot: {
       useSerieColor: true,
       fill: selectedRangeColor.value,
@@ -469,10 +464,8 @@ function drawLastDatapointLabel(svg: VueUiXySvgSlotProps['svg']) {
       background: colors.value.bg!,
       fallbackSerieColor: colors.value.textMuted!,
     },
-    formatValue: (value, serie) =>
-      Number.isFinite(value)
-        ? `${value.toFixed(0)}${serie.name === SERIES.PR_COUNT ? '' : '%'}`
-        : '-',
+    formatValue: (value) =>
+      Number.isFinite(value) ? `${value.toFixed(0)}%` : '-',
     isDarkMode: isDarkMode.value,
   })
 }
@@ -510,8 +503,6 @@ type TooltipRow = {
   color: string
   value: string
   detail: string
-  eligiblePrCount: number
-  label: string
 }
 
 function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
@@ -535,25 +526,14 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
           ? 100
           : Math.round((closed / eligible) * 100)
 
-    const isCount = datapoint.name === SERIES.PR_COUNT
-
     return {
       key: repoName,
       owner: owner!,
       repo,
-      color: isCount
-        ? (datapoint?.color ?? '#666666')
-        : (selectedRangeColor.value ?? 'currentColor'),
-      eligiblePrCount: eligible ?? 0,
-      label: isCount ? datapoint.name : 'Closure rate',
-      value: isCount
-        ? String(eligible ?? 0)
-        : Number.isFinite(percentage)
-          ? `${percentage.toFixed(0)}%`
-          : '-',
-      detail: isCount
-        ? ''
-        : closed == null || eligible == null
+      color: selectedRangeColor.value ?? 'currentColor',
+      value: Number.isFinite(percentage) ? `${percentage.toFixed(0)}%` : '-',
+      detail:
+        closed == null || eligible == null
           ? 'No data'
           : `${closed} / ${eligible}`,
     }
@@ -748,40 +728,16 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
               </g>
             </template>
 
-            <template #legend="{ legend }">
-              <div class="flex flex-row gap-4 justify-center mt-2">
-                <button
-                  v-for="item in legend"
-                  :key="item.id"
-                  class="flex flex-row gap-1.5 place-items-center"
-                  :class="item.isSegregated ? 'opacity-50' : 'hover:underline'"
-                  @click="item.segregate()"
-                >
-                  <div class="w-4 h-4">
-                    <svg viewBox="0 0 2 2" class="w-full h-full">
-                      <circle :cx="1" :cy="1" :r="1" :fill="item.color" />
-                    </svg>
-                  </div>
-                  <div
-                    :class="`text-gh-muted text-sm ${item.isSegregated ? 'line-through' : ''}`"
-                  >
-                    {{
-                      item?.independant ? SERIES.PR_COUNT : SERIES.CLOSURE_RATE
-                    }}
-                  </div>
-                </button>
-              </div>
-            </template>
-
             <!-- CUSTOM TOOLTIP -->
-            <template #tooltip="{ timeLabel, datapoint }">
+            <template #tooltip="{ timeLabel }">
               <div class="min-w-[220px] text-xs">
                 <div class="mb-2 font-medium text-gh-muted">
-                  {{ timeLabel.text }} - {{ datapoint[0]?.name }}
+                  {{ timeLabel.text }}
                 </div>
+
                 <div class="flex flex-col gap-1.5">
                   <div
-                    v-for="(row, i) in getTooltipRows(timeLabel)"
+                    v-for="row in getTooltipRows(timeLabel)"
                     :key="row.key"
                     class="grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2"
                   >
@@ -791,7 +747,8 @@ function getTooltipRows(timeLabel: VueUiXyTooltipSlotProps['timeLabel']) {
                       aria-hidden="true"
                     />
                     <span class="min-w-0 truncate text-left">
-                      <span>{{ row.label }}</span>
+                      <span class="text-gh-muted"> {{ row.owner }}/ </span>
+                      <span>{{ row.repo }}</span>
                     </span>
                     <span class="text-gh-muted tabular-nums">
                       {{ row.detail }}

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -1,6 +1,11 @@
 import type { VueUiHorizontalBarDatasetItem } from 'vue-data-ui/vue-ui-horizontal-bar'
 import type { VueUiXyDatasetItem } from 'vue-data-ui/vue-ui-xy'
 
+export const SERIES = {
+  PR_COUNT: 'PR count',
+  CLOSURE_RATE: 'PR closure rate',
+}
+
 export function getCompleteDayRange(days: string[]): string[] {
   if (!days.length) {
     return []
@@ -243,7 +248,7 @@ export function getClosedPrPercentageEvolutionByRepo(
   source: EcosystemHealthItem[] = [],
   scoreBounds: ScoreBounds = [0, 100],
   dateKey: keyof EcosystemHealthItem = 'created_at',
-): Array<Array<VueUiXyDatasetItem & { hasData: boolean }>> {
+): Array<Array<VueUiXyDatasetItem & { hasData?: boolean }>> {
   const dates = getUniqueDatesFromSource(source, dateKey)
 
   const repoMap = new Map<
@@ -289,6 +294,18 @@ export function getClosedPrPercentageEvolutionByRepo(
       type: 'line',
       smooth: true,
       hasData: data.percentages.some((value) => value !== null),
+      details: {
+        eligiblePrs: data.eligiblePrs,
+        closedPrs: data.closedPrs,
+      },
+    },
+    {
+      name: SERIES.PR_COUNT,
+      series: data.eligiblePrs,
+      type: 'line',
+      smooth: true,
+      dashed: true,
+      independant: true,
       details: {
         eligiblePrs: data.eligiblePrs,
         closedPrs: data.closedPrs,
@@ -456,12 +473,13 @@ export function createLastDatapointLabelsSvg({
     bottom?: number
   }
   colors: LastDatapointLabelColors
-  formatValue: (value: number) => string
+  formatValue: (value: number, series: LastDatapointLabelSerie) => string
   isDarkMode: boolean
   svgWidth?: number
   fontSize?: number
   labelOffset?: number
   labelHeight?: number
+  suffix?: string
 }) {
   const drawingAreaTop = Number(drawingArea.top ?? 0)
   const drawingAreaHeight = Number(
@@ -478,7 +496,7 @@ export function createLastDatapointLabelsSvg({
 
       const value = Number(lastPlot.value ?? 0)
       const safeValue = Number.isFinite(value) ? value : 0
-      const text = formatValue(safeValue)
+      const text = formatValue(safeValue, serie)
 
       return {
         x: Number(lastPlot.x ?? 0),
@@ -614,6 +632,7 @@ export type LastDatapointLabelSerie = {
     y?: number | null
     value?: number | null
   }[]
+  name: string
 }
 
 type LastDatapointLabel = {

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -1,11 +1,6 @@
 import type { VueUiHorizontalBarDatasetItem } from 'vue-data-ui/vue-ui-horizontal-bar'
 import type { VueUiXyDatasetItem } from 'vue-data-ui/vue-ui-xy'
 
-export const SERIES = {
-  PR_COUNT: 'PR count',
-  CLOSURE_RATE: 'PR closure rate',
-}
-
 export function getCompleteDayRange(days: string[]): string[] {
   if (!days.length) {
     return []
@@ -248,7 +243,7 @@ export function getClosedPrPercentageEvolutionByRepo(
   source: EcosystemHealthItem[] = [],
   scoreBounds: ScoreBounds = [0, 100],
   dateKey: keyof EcosystemHealthItem = 'created_at',
-): Array<Array<VueUiXyDatasetItem & { hasData?: boolean }>> {
+): Array<Array<VueUiXyDatasetItem & { hasData: boolean }>> {
   const dates = getUniqueDatesFromSource(source, dateKey)
 
   const repoMap = new Map<
@@ -294,18 +289,6 @@ export function getClosedPrPercentageEvolutionByRepo(
       type: 'line',
       smooth: true,
       hasData: data.percentages.some((value) => value !== null),
-      details: {
-        eligiblePrs: data.eligiblePrs,
-        closedPrs: data.closedPrs,
-      },
-    },
-    {
-      name: SERIES.PR_COUNT,
-      series: data.eligiblePrs,
-      type: 'line',
-      smooth: true,
-      dashed: true,
-      independant: true,
       details: {
         eligiblePrs: data.eligiblePrs,
         closedPrs: data.closedPrs,
@@ -473,13 +456,12 @@ export function createLastDatapointLabelsSvg({
     bottom?: number
   }
   colors: LastDatapointLabelColors
-  formatValue: (value: number, series: LastDatapointLabelSerie) => string
+  formatValue: (value: number) => string
   isDarkMode: boolean
   svgWidth?: number
   fontSize?: number
   labelOffset?: number
   labelHeight?: number
-  suffix?: string
 }) {
   const drawingAreaTop = Number(drawingArea.top ?? 0)
   const drawingAreaHeight = Number(
@@ -496,7 +478,7 @@ export function createLastDatapointLabelsSvg({
 
       const value = Number(lastPlot.value ?? 0)
       const safeValue = Number.isFinite(value) ? value : 0
-      const text = formatValue(safeValue, serie)
+      const text = formatValue(safeValue)
 
       return {
         x: Number(lastPlot.x ?? 0),
@@ -632,7 +614,6 @@ export type LastDatapointLabelSerie = {
     y?: number | null
     value?: number | null
   }[]
-  name: string
 }
 
 type LastDatapointLabel = {

--- a/test/unit/shared/utils/charts.test.ts
+++ b/test/unit/shared/utils/charts.test.ts
@@ -10,6 +10,8 @@ import {
   getClosedPrPercentageTotal,
   getClosedPrDelta,
   createLastDatapointLabelsSvg,
+  SERIES,
+  type LastDatapointLabelSerie,
 } from '../../../../shared/utils/charts'
 import {
   EXPECTED_NB_UNIQUE_REPOS,
@@ -183,7 +185,7 @@ describe('getClosedPrPercentageEvolutionByRepo', () => {
 
     expect(result).toHaveLength(EXPECTED_NB_UNIQUE_REPOS)
     const flatResult = result.flat()
-    expect(flatResult).toHaveLength(EXPECTED_NB_UNIQUE_REPOS)
+    expect(flatResult).toHaveLength(EXPECTED_NB_UNIQUE_REPOS * 2)
 
     flatResult.forEach((item) => {
       expect(item).toEqual(
@@ -192,13 +194,28 @@ describe('getClosedPrPercentageEvolutionByRepo', () => {
           series: expect.any(Array),
           type: 'line',
           smooth: true,
-          hasData: expect.any(Boolean),
           details: expect.objectContaining({
             eligiblePrs: expect.any(Array),
             closedPrs: expect.any(Array),
           }),
         }),
       )
+
+      if (item.name === SERIES.PR_COUNT) {
+        expect(item).toEqual(
+          expect.objectContaining({
+            dashed: true,
+            independant: true,
+          }),
+        )
+        expect(item).not.toHaveProperty('hasData')
+      } else {
+        expect(item).toEqual(
+          expect.objectContaining({
+            hasData: expect.any(Boolean),
+          }),
+        )
+      }
 
       expect(item.series.every((value) => typeof value === 'number')).toBe(true)
       expect(
@@ -394,6 +411,13 @@ const colors = {
   fallbackSerieColor: '#999999',
 }
 
+function createSerie(
+  name: string,
+  serie: Omit<LastDatapointLabelSerie, 'name'> = {},
+): LastDatapointLabelSerie {
+  return { name, ...serie }
+}
+
 describe('createLastDatapointLabelsSvg', () => {
   it('returns an empty string when there are no series', () => {
     const result = createLastDatapointLabelsSvg({
@@ -409,7 +433,10 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('returns an empty string when no serie has plots', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [{ color: '#FF0000' }, { color: '#00FF00', plots: [] }],
+      series: [
+        createSerie('First series', { color: '#FF0000' }),
+        createSerie('Second series', { color: '#00FF00', plots: [] }),
+      ],
       drawingArea: { top: 10, height: 100 },
       colors,
       formatValue: (value) => String(value),
@@ -422,8 +449,14 @@ describe('createLastDatapointLabelsSvg', () => {
   it('renders regular labels when there is no collision', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 20, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 90, value: 20 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 20, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 90, value: 20 }],
+        }),
       ],
       drawingArea: { top: 0, height: 120 },
       colors,
@@ -442,7 +475,11 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('uses custom font size, label offset, and colors in regular labels', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [{ plots: [{ x: 10, y: 20, value: 42 }] }],
+      series: [
+        createSerie('First series', {
+          plots: [{ x: 10, y: 20, value: 42 }],
+        }),
+      ],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `${value}`,
@@ -457,19 +494,21 @@ describe('createLastDatapointLabelsSvg', () => {
     expect(result).toContain('stroke="#FFFFFF"')
   })
 
-  it('uses only the last plot of each serie', () => {
-    const formatValue = vi.fn((value: number) => `${value}`)
+  it('uses only the last plot and passes its serie to formatValue', () => {
+    const formatValue = vi.fn(
+      (value: number, serie: LastDatapointLabelSerie) =>
+        `${serie.name}:${value}`,
+    )
+    const serie = createSerie('First series', {
+      color: '#FF0000',
+      plots: [
+        { x: 10, y: 10, value: 1 },
+        { x: 50, y: 50, value: 99 },
+      ],
+    })
 
     const result = createLastDatapointLabelsSvg({
-      series: [
-        {
-          color: '#FF0000',
-          plots: [
-            { x: 10, y: 10, value: 1 },
-            { x: 50, y: 50, value: 99 },
-          ],
-        },
-      ],
+      series: [serie],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue,
@@ -477,33 +516,49 @@ describe('createLastDatapointLabelsSvg', () => {
     })
 
     expect(formatValue).toHaveBeenCalledTimes(1)
-    expect(formatValue).toHaveBeenCalledWith(99)
+    expect(formatValue).toHaveBeenCalledWith(99, serie)
+    expect(result).toContain('First series:99')
     expect(result).toContain('x="74"')
     expect(result).toContain('y="50"')
     expect(result).not.toContain('x="34"')
   })
 
   it('formats safe numeric values and falls back to zero for invalid values', () => {
-    const formatValue = vi.fn((value: number) => `value:${value}`)
+    const formatValue = vi.fn(
+      (value: number, serie: LastDatapointLabelSerie) =>
+        `${serie.name}:${value}`,
+    )
+    const serie = createSerie('Invalid value series', {
+      plots: [{ x: 10, y: 20, value: Number.NaN }],
+    })
 
     const result = createLastDatapointLabelsSvg({
-      series: [{ plots: [{ x: 10, y: 20, value: Number.NaN }] }],
+      series: [serie],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue,
       isDarkMode: false,
     })
 
-    expect(formatValue).toHaveBeenCalledWith(0)
-    expect(result).toContain('value:0')
+    expect(formatValue).toHaveBeenCalledWith(0, serie)
+    expect(result).toContain('Invalid value series:0')
   })
 
   it('renders collision labels as a compact non-overlapping label rack', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 30 }] },
-        { color: '#0000FF', plots: [{ x: 100, y: 60, value: 20 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 55, value: 30 }],
+        }),
+        createSerie('Third series', {
+          color: '#0000FF',
+          plots: [{ x: 100, y: 60, value: 20 }],
+        }),
       ],
       drawingArea: { top: 10, height: 120 },
       colors,
@@ -526,8 +581,14 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses drawingArea.bottom when height is not provided', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 20 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 55, value: 20 }],
+        }),
       ],
       drawingArea: { top: 20, bottom: 120 },
       colors,
@@ -542,9 +603,18 @@ describe('createLastDatapointLabelsSvg', () => {
   it('keeps colliding labels close to their related points without overlapping', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 40, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 45, value: 20 }] },
-        { color: '#0000FF', plots: [{ x: 100, y: 95, value: 30 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 40, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 45, value: 20 }],
+        }),
+        createSerie('Third series', {
+          color: '#0000FF',
+          plots: [{ x: 100, y: 95, value: 30 }],
+        }),
       ],
       drawingArea: { top: 0, height: 120 },
       colors,
@@ -560,9 +630,18 @@ describe('createLastDatapointLabelsSvg', () => {
   it('shifts the label stack upward when it overflows the drawing area bottom', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 80, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 85, value: 20 }] },
-        { color: '#0000FF', plots: [{ x: 100, y: 90, value: 30 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 80, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 85, value: 20 }],
+        }),
+        createSerie('Third series', {
+          color: '#0000FF',
+          plots: [{ x: 100, y: 90, value: 30 }],
+        }),
       ],
       drawingArea: { top: 0, height: 120 },
       colors,
@@ -578,8 +657,14 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses dark-mode opacity in collision mode', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 50, value: 20 }],
+        }),
       ],
       drawingArea: { top: 0, height: 100 },
       colors,
@@ -593,8 +678,12 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses the fallback serie color when no color is provided', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { plots: [{ x: 100, y: 50, value: 10 }] },
-        { plots: [{ x: 100, y: 50, value: 20 }] },
+        createSerie('First series', {
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+        createSerie('Second series', {
+          plots: [{ x: 100, y: 50, value: 20 }],
+        }),
       ],
       drawingArea: { top: 0, height: 100 },
       colors,
@@ -607,7 +696,11 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('supports null plot values from SSR slot data', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [{ plots: [{ x: 10, y: 20, value: null }] }],
+      series: [
+        createSerie('First series', {
+          plots: [{ x: 10, y: 20, value: null }],
+        }),
+      ],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `formatted:${value}`,
@@ -619,7 +712,11 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('uses zero defaults when plot coordinates are nullish', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [{ plots: [{ x: null, y: null, value: undefined }] }],
+      series: [
+        createSerie('First series', {
+          plots: [{ x: null, y: null, value: undefined }],
+        }),
+      ],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `value-${value}`,
@@ -634,8 +731,14 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses zero drawing area height when neither height nor bottom is provided', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 50, value: 20 }],
+        }),
       ],
       drawingArea: { top: 20 },
       colors,
@@ -649,7 +752,11 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('renders a regular label when serie color is omitted', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [{ plots: [{ x: 100, y: 50, value: 10 }] }],
+      series: [
+        createSerie('First series', {
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+      ],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `${value}`,
@@ -665,8 +772,14 @@ describe('createLastDatapointLabelsSvg', () => {
   it('supports custom labelHeight in collision rack mode', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
-        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
+        createSerie('First series', {
+          color: '#FF0000',
+          plots: [{ x: 100, y: 50, value: 10 }],
+        }),
+        createSerie('Second series', {
+          color: '#00FF00',
+          plots: [{ x: 100, y: 50, value: 20 }],
+        }),
       ],
       drawingArea: { top: 10, height: 110 },
       colors,

--- a/test/unit/shared/utils/charts.test.ts
+++ b/test/unit/shared/utils/charts.test.ts
@@ -10,8 +10,6 @@ import {
   getClosedPrPercentageTotal,
   getClosedPrDelta,
   createLastDatapointLabelsSvg,
-  SERIES,
-  type LastDatapointLabelSerie,
 } from '../../../../shared/utils/charts'
 import {
   EXPECTED_NB_UNIQUE_REPOS,
@@ -185,7 +183,7 @@ describe('getClosedPrPercentageEvolutionByRepo', () => {
 
     expect(result).toHaveLength(EXPECTED_NB_UNIQUE_REPOS)
     const flatResult = result.flat()
-    expect(flatResult).toHaveLength(EXPECTED_NB_UNIQUE_REPOS * 2)
+    expect(flatResult).toHaveLength(EXPECTED_NB_UNIQUE_REPOS)
 
     flatResult.forEach((item) => {
       expect(item).toEqual(
@@ -194,28 +192,13 @@ describe('getClosedPrPercentageEvolutionByRepo', () => {
           series: expect.any(Array),
           type: 'line',
           smooth: true,
+          hasData: expect.any(Boolean),
           details: expect.objectContaining({
             eligiblePrs: expect.any(Array),
             closedPrs: expect.any(Array),
           }),
         }),
       )
-
-      if (item.name === SERIES.PR_COUNT) {
-        expect(item).toEqual(
-          expect.objectContaining({
-            dashed: true,
-            independant: true,
-          }),
-        )
-        expect(item).not.toHaveProperty('hasData')
-      } else {
-        expect(item).toEqual(
-          expect.objectContaining({
-            hasData: expect.any(Boolean),
-          }),
-        )
-      }
 
       expect(item.series.every((value) => typeof value === 'number')).toBe(true)
       expect(
@@ -411,13 +394,6 @@ const colors = {
   fallbackSerieColor: '#999999',
 }
 
-function createSerie(
-  name: string,
-  serie: Omit<LastDatapointLabelSerie, 'name'> = {},
-): LastDatapointLabelSerie {
-  return { name, ...serie }
-}
-
 describe('createLastDatapointLabelsSvg', () => {
   it('returns an empty string when there are no series', () => {
     const result = createLastDatapointLabelsSvg({
@@ -433,10 +409,7 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('returns an empty string when no serie has plots', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [
-        createSerie('First series', { color: '#FF0000' }),
-        createSerie('Second series', { color: '#00FF00', plots: [] }),
-      ],
+      series: [{ color: '#FF0000' }, { color: '#00FF00', plots: [] }],
       drawingArea: { top: 10, height: 100 },
       colors,
       formatValue: (value) => String(value),
@@ -449,14 +422,8 @@ describe('createLastDatapointLabelsSvg', () => {
   it('renders regular labels when there is no collision', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 20, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 90, value: 20 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 20, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 90, value: 20 }] },
       ],
       drawingArea: { top: 0, height: 120 },
       colors,
@@ -475,11 +442,7 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('uses custom font size, label offset, and colors in regular labels', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [
-        createSerie('First series', {
-          plots: [{ x: 10, y: 20, value: 42 }],
-        }),
-      ],
+      series: [{ plots: [{ x: 10, y: 20, value: 42 }] }],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `${value}`,
@@ -494,21 +457,19 @@ describe('createLastDatapointLabelsSvg', () => {
     expect(result).toContain('stroke="#FFFFFF"')
   })
 
-  it('uses only the last plot and passes its serie to formatValue', () => {
-    const formatValue = vi.fn(
-      (value: number, serie: LastDatapointLabelSerie) =>
-        `${serie.name}:${value}`,
-    )
-    const serie = createSerie('First series', {
-      color: '#FF0000',
-      plots: [
-        { x: 10, y: 10, value: 1 },
-        { x: 50, y: 50, value: 99 },
-      ],
-    })
+  it('uses only the last plot of each serie', () => {
+    const formatValue = vi.fn((value: number) => `${value}`)
 
     const result = createLastDatapointLabelsSvg({
-      series: [serie],
+      series: [
+        {
+          color: '#FF0000',
+          plots: [
+            { x: 10, y: 10, value: 1 },
+            { x: 50, y: 50, value: 99 },
+          ],
+        },
+      ],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue,
@@ -516,49 +477,33 @@ describe('createLastDatapointLabelsSvg', () => {
     })
 
     expect(formatValue).toHaveBeenCalledTimes(1)
-    expect(formatValue).toHaveBeenCalledWith(99, serie)
-    expect(result).toContain('First series:99')
+    expect(formatValue).toHaveBeenCalledWith(99)
     expect(result).toContain('x="74"')
     expect(result).toContain('y="50"')
     expect(result).not.toContain('x="34"')
   })
 
   it('formats safe numeric values and falls back to zero for invalid values', () => {
-    const formatValue = vi.fn(
-      (value: number, serie: LastDatapointLabelSerie) =>
-        `${serie.name}:${value}`,
-    )
-    const serie = createSerie('Invalid value series', {
-      plots: [{ x: 10, y: 20, value: Number.NaN }],
-    })
+    const formatValue = vi.fn((value: number) => `value:${value}`)
 
     const result = createLastDatapointLabelsSvg({
-      series: [serie],
+      series: [{ plots: [{ x: 10, y: 20, value: Number.NaN }] }],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue,
       isDarkMode: false,
     })
 
-    expect(formatValue).toHaveBeenCalledWith(0, serie)
-    expect(result).toContain('Invalid value series:0')
+    expect(formatValue).toHaveBeenCalledWith(0)
+    expect(result).toContain('value:0')
   })
 
   it('renders collision labels as a compact non-overlapping label rack', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 55, value: 30 }],
-        }),
-        createSerie('Third series', {
-          color: '#0000FF',
-          plots: [{ x: 100, y: 60, value: 20 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 30 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 60, value: 20 }] },
       ],
       drawingArea: { top: 10, height: 120 },
       colors,
@@ -581,14 +526,8 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses drawingArea.bottom when height is not provided', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 55, value: 20 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 55, value: 20 }] },
       ],
       drawingArea: { top: 20, bottom: 120 },
       colors,
@@ -603,18 +542,9 @@ describe('createLastDatapointLabelsSvg', () => {
   it('keeps colliding labels close to their related points without overlapping', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 40, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 45, value: 20 }],
-        }),
-        createSerie('Third series', {
-          color: '#0000FF',
-          plots: [{ x: 100, y: 95, value: 30 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 40, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 45, value: 20 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 95, value: 30 }] },
       ],
       drawingArea: { top: 0, height: 120 },
       colors,
@@ -630,18 +560,9 @@ describe('createLastDatapointLabelsSvg', () => {
   it('shifts the label stack upward when it overflows the drawing area bottom', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 80, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 85, value: 20 }],
-        }),
-        createSerie('Third series', {
-          color: '#0000FF',
-          plots: [{ x: 100, y: 90, value: 30 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 80, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 85, value: 20 }] },
+        { color: '#0000FF', plots: [{ x: 100, y: 90, value: 30 }] },
       ],
       drawingArea: { top: 0, height: 120 },
       colors,
@@ -657,14 +578,8 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses dark-mode opacity in collision mode', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 50, value: 20 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
       ],
       drawingArea: { top: 0, height: 100 },
       colors,
@@ -678,12 +593,8 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses the fallback serie color when no color is provided', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-        createSerie('Second series', {
-          plots: [{ x: 100, y: 50, value: 20 }],
-        }),
+        { plots: [{ x: 100, y: 50, value: 10 }] },
+        { plots: [{ x: 100, y: 50, value: 20 }] },
       ],
       drawingArea: { top: 0, height: 100 },
       colors,
@@ -696,11 +607,7 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('supports null plot values from SSR slot data', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [
-        createSerie('First series', {
-          plots: [{ x: 10, y: 20, value: null }],
-        }),
-      ],
+      series: [{ plots: [{ x: 10, y: 20, value: null }] }],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `formatted:${value}`,
@@ -712,11 +619,7 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('uses zero defaults when plot coordinates are nullish', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [
-        createSerie('First series', {
-          plots: [{ x: null, y: null, value: undefined }],
-        }),
-      ],
+      series: [{ plots: [{ x: null, y: null, value: undefined }] }],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `value-${value}`,
@@ -731,14 +634,8 @@ describe('createLastDatapointLabelsSvg', () => {
   it('uses zero drawing area height when neither height nor bottom is provided', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 50, value: 20 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
       ],
       drawingArea: { top: 20 },
       colors,
@@ -752,11 +649,7 @@ describe('createLastDatapointLabelsSvg', () => {
 
   it('renders a regular label when serie color is omitted', () => {
     const result = createLastDatapointLabelsSvg({
-      series: [
-        createSerie('First series', {
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-      ],
+      series: [{ plots: [{ x: 100, y: 50, value: 10 }] }],
       drawingArea: { top: 0, height: 100 },
       colors,
       formatValue: (value) => `${value}`,
@@ -772,14 +665,8 @@ describe('createLastDatapointLabelsSvg', () => {
   it('supports custom labelHeight in collision rack mode', () => {
     const result = createLastDatapointLabelsSvg({
       series: [
-        createSerie('First series', {
-          color: '#FF0000',
-          plots: [{ x: 100, y: 50, value: 10 }],
-        }),
-        createSerie('Second series', {
-          color: '#00FF00',
-          plots: [{ x: 100, y: 50, value: 20 }],
-        }),
+        { color: '#FF0000', plots: [{ x: 100, y: 50, value: 10 }] },
+        { color: '#00FF00', plots: [{ x: 100, y: 50, value: 20 }] },
       ],
       drawingArea: { top: 10, height: 110 },
       colors,


### PR DESCRIPTION
In an attempt to make sense of the closure rates, this adds the PR count as a second series to the featured repos sparkline charts in the lab.

<img width="766" height="435" alt="image" src="https://github.com/user-attachments/assets/8b733ef3-60ee-484b-93f8-3408db375ad7" />

A legend with togglable items allows to filter series to only display the rate or the count.
The tootlip content was also adapted.