### PR TITLE
fix: improve hourly health chart layout

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -270,10 +270,6 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
     }
   })
 }
-
-function log(n: any) {
-  console.log(n)
-}
 </script>
 
 <template>

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -3,6 +3,7 @@ import {
   VueUiXy,
   type VueUiXyConfig,
   type VueUiXyDatasetItem,
+  type VueUiXyDatasetLineItem,
 } from 'vue-data-ui/vue-ui-xy'
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { useElementSize } from '@vueuse/core'
@@ -102,7 +103,7 @@ const axisTimeFormat = 'HH:mm'
 // A rolling day of scans is too many labels for one axis, so only every nth one
 // is drawn.
 const labelModulo = computed(() => {
-  const maxLabels = isMobile.value ? 4 : 8
+  const maxLabels = isMobile.value ? 4 : 12
   return Math.max(1, Math.ceil(scanTimes.value.length / maxLabels))
 })
 
@@ -111,14 +112,16 @@ const config = computed<VueUiXyConfig>(() => ({
   chart: {
     userOptions: { show: false },
     zoom: { show: false },
-    legend: { show: false },
+    legend: { show: false, position: 'top' },
     backgroundColor: colors.value.bg,
     color: colors.value.textMuted,
     width: Math.round(width.value),
-    height: 340,
+    height: 300,
     padding: {
-      right: 12,
-      bottom: 42,
+      top: 0,
+      right: 0,
+      left: 0,
+      bottom: 0,
     },
     highlighter: {
       opacity: 1,
@@ -138,7 +141,7 @@ const config = computed<VueUiXyConfig>(() => ({
       stroke: 'transparent',
       showVerticalLines: false,
       labels: {
-        show: true,
+        show: false,
         fontSize: 12,
         color: colors.value.textMuted,
         yAxis: {
@@ -227,6 +230,50 @@ function getScanDetails({
 
   return `${count} / ${total}`
 }
+
+type Datapoints = Array<VueUiXyDatasetLineItem & { alerts: boolean[] }>
+
+type PlotAlert = {
+  name: string
+  coordinates: Array<{
+    x: number
+    y: number
+    absoluteIndex: number
+    isAlert: boolean
+  }>
+}
+
+function isAlert(value: VueUiXyDatasetItem['series'][0], threshold: number) {
+  return value != null && (value as number) > threshold
+}
+
+function getZapIconPath({ x, y }: { x: number; y: number }) {
+  // ⚡ with relative coordinates from initial position
+  return `M ${x} ${y} l 12 -17 l -6 0 l 3 -13 l -11 17 l 6 0 l -4 13`
+}
+
+function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
+  return data.map((d) => {
+    return {
+      name: d.name,
+      coordinates: d.plots!.map((plot, index) => {
+        const absoluteIndex = index + zoomOffset
+
+        return {
+          ...plot,
+          absoluteIndex,
+          isAlert:
+            d.name === 'Automation' &&
+            isAlert(d.absoluteValues[absoluteIndex]!, 25),
+        }
+      }),
+    }
+  })
+}
+
+function log(n: any) {
+  console.log(n)
+}
 </script>
 
 <template>
@@ -246,6 +293,34 @@ function getScanDetails({
     <ClientOnly v-else>
       <div ref="chartContainer" class="w-full">
         <VueUiXy v-if="hasStableChartWidth" ref="chartRef" :dataset :config>
+          <template #svg="{ svg }">
+            <g
+              v-for="alerts in alertIcons(
+                svg.data as Datapoints,
+                svg.slicer.start,
+              )"
+              :key="alerts.name"
+            >
+              <template
+                v-for="plot in alerts.coordinates"
+                :key="`${alerts.name}-${plot.absoluteIndex}`"
+              >
+                <path
+                  v-show="plot.isAlert"
+                  class="zap-icon"
+                  :d="
+                    getZapIconPath({
+                      x: plot.x - 4,
+                      y: plot.y - 6,
+                    })
+                  "
+                  :fill="colors.amber"
+                  :stroke="colors.bg"
+                />
+              </template>
+            </g>
+          </template>
+
           <template #area-gradient="{ series, id }">
             <linearGradient :id x1="0" x2="0" y1="0" y2="1">
               <stop offset="0%" :stop-color="series.color" stop-opacity="0.3" />
@@ -318,8 +393,6 @@ function getScanDetails({
                 v-for="item in legend"
                 :key="item.id"
                 class="flex flex-row gap-1.5 place-items-center"
-                :class="item.isSegregated ? 'opacity-50' : 'hover:underline'"
-                @click="item.segregate()"
               >
                 <div class="w-3 h-3">
                   <svg viewBox="0 0 2 2" class="w-full h-full">

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.22.12",
+    "vue-data-ui": "^3.23.0",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.22.12
-        version: 3.22.12(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.23.0
+        version: 3.23.0(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -6084,8 +6084,8 @@ packages:
   vue-bundle-renderer@2.3.1:
     resolution: {integrity: sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==}
 
-  vue-data-ui@3.22.12:
-    resolution: {integrity: sha512-kt8PpMx07xIHWkmi6wOeYEOA6VHEfpn10UzJnek2EOCbr41GrFEMK6405uyRgFe5b6cvBnNwMdlfB0UI2soRgQ==}
+  vue-data-ui@3.23.0:
+    resolution: {integrity: sha512-Drgg76fb+eOn5yLFsUX7Kvfs3Fcyfpv0QKXL8EVfprklTeyWseeqeiP2yJWWSFD79JfB/4Ap6Dwtp2/w1RiwMw==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -12868,7 +12868,7 @@ snapshots:
     dependencies:
       ufo: 1.6.4
 
-  vue-data-ui@3.22.12(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.23.0(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 


### PR DESCRIPTION
- chart face lift + zap icon when clank ratio > 25%
- new and shiny vue-data-ui 3.23.0

<img width="749" height="463" alt="image" src="https://github.com/user-attachments/assets/568656bb-9575-4f1b-8641-28e7904fb562" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual alerts for Automation chart points exceeding 25%, using amber lightning icons.
  * Improved chart responsiveness, sizing, label density, and legend behavior for clearer data presentation.

* **Chores**
  * Updated the charting library to the latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->