### PR TITLE
fix: show datapoints when single entry only

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -97,6 +97,8 @@ const dataset = computed<VueUiXyDatasetItem[]>(() =>
   })),
 )
 
+const hasSingleEntry = computed(() => dataset.value[0]?.series.length === 1)
+
 // Axis labels stay short — the tooltip carries the full timestamp.
 const axisTimeFormat = 'HH:mm'
 
@@ -175,7 +177,7 @@ const config = computed<VueUiXyConfig>(() => ({
     },
   },
   line: {
-    radius: 0,
+    radius: hasSingleEntry.value ? 4 : 0,
     useGradient: false,
     strokeWidth: isMobile.value ? 1.5 : 2,
     dot: {


### PR DESCRIPTION
This fixes the invisible plots when there is only a single entry on the hourly health chart

<img width="770" height="454" alt="image" src="https://github.com/user-attachments/assets/d3c4e82a-7e30-4a80-84ed-5e302d95902c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart readability when only one data point is available by displaying a visible marker.
  * Preserved the existing line appearance for charts with multiple data points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->