### PR TITLE
fix: round hourly timestamps to closest hour

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -14,9 +14,7 @@ import('vue-data-ui/style.css')
 
 const { data } = useEcosystemHealthHourly()
 
-const scanTimes = computed(() => {
-  return data.value?.scanTimes ?? []
-})
+const scanTimes = computed(() => data.value?.scanTimes ?? [])
 const countsByScanTime = computed(() => data.value?.countsByScanTime)
 const hasData = computed(() => scanTimes.value.length > 0)
 

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -14,7 +14,9 @@ import('vue-data-ui/style.css')
 
 const { data } = useEcosystemHealthHourly()
 
-const scanTimes = computed(() => data.value?.scanTimes ?? [])
+const scanTimes = computed(() => {
+  return data.value?.scanTimes ?? []
+})
 const countsByScanTime = computed(() => data.value?.countsByScanTime)
 const hasData = computed(() => scanTimes.value.length > 0)
 

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -47,7 +47,9 @@ const { data } = await useEcosystemHealth({ full: true })
         <LazyChartScoreDistribution :data="data?.results" hydrate-on-visible />
       </div>
       <div class="w-full">
-        <LazyReportWeeklyClassification hydrate-on-visible />
+        <LazyReportWeeklyClassification
+          :hydrate-on-visible="{ rootMargin: '600px 0px' }"
+        />
       </div>
       <div class="w-full">
         <LazyChartFeaturedPackageHealthRanking hydrate-on-visible />

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -48,7 +48,7 @@ const { data } = await useEcosystemHealth({ full: true })
       </div>
       <div class="w-full">
         <LazyReportWeeklyClassification
-          :hydrate-on-visible="{ rootMargin: '600px 0px' }"
+          :hydrate-on-visible="{ rootMargin: '0px 0px 600px 0px' }"
         />
       </div>
       <div class="w-full">

--- a/server/api/health/hourly.get.ts
+++ b/server/api/health/hourly.get.ts
@@ -2,6 +2,7 @@ import type { EcosystemHealthCategoryProgression } from '~~/shared/types/ecosyst
 
 import { unpack } from '~~/shared/utils/compactor'
 import { getClassificationStatsByScanTime } from '~~/shared/utils/count-classification-by-date'
+import { roundToClosestHour } from '~~/shared/utils/dates'
 
 export default defineEventHandler(async () => {
   try {
@@ -14,7 +15,10 @@ export default defineEventHandler(async () => {
     }
 
     const content = Buffer.isBuffer(raw) ? raw.toString('utf-8') : String(raw)
-    const results = unpack(content)
+    const results = unpack(content).map((entry) => ({
+      ...entry,
+      created_at: roundToClosestHour(entry.created_at),
+    }))
 
     const automationPercentages: number[] = []
     const mixedPercentages: number[] = []

--- a/shared/utils/dates.ts
+++ b/shared/utils/dates.ts
@@ -63,7 +63,7 @@ export function formatDateRange({
 export function roundToClosestHour(timestamp: string): string {
   const date = dayjs(timestamp)
   if (!date.isValid()) {
-    throw new TypeError(`Invalid timestamp: "${timestamp}"`)
+    return timestamp
   }
   return date.utc().add(30, 'minute').startOf('hour').toISOString()
 }

--- a/shared/utils/dates.ts
+++ b/shared/utils/dates.ts
@@ -59,3 +59,11 @@ export function formatDateRange({
 
   return `${startLabel} - ${endLabel}`
 }
+
+export function roundToClosestHour(timestamp: string): string {
+  const date = dayjs(timestamp)
+  if (!date.isValid()) {
+    throw new TypeError(`Invalid timestamp: "${timestamp}"`)
+  }
+  return date.utc().add(30, 'minute').startOf('hour').toISOString()
+}

--- a/test/unit/shared/utils/dates.test.ts
+++ b/test/unit/shared/utils/dates.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { formatDateRange } from '../../../../shared/utils/dates'
+import {
+  formatDateRange,
+  roundToClosestHour,
+} from '../../../../shared/utils/dates'
 
 describe('formatDateRange', () => {
   it('formats a date range with YYYY-MM-DD inputs', () => {
@@ -116,4 +119,65 @@ describe('formatDateRange', () => {
       }),
     ).toBe('')
   })
+})
+
+describe('roundToClosestHour', () => {
+  it.each([
+    {
+      timestamp: '2026-08-05T06:00:00.000Z',
+      expected: '2026-08-05T06:00:00.000Z',
+    },
+    {
+      timestamp: '2026-08-05T06:01:14.000Z',
+      expected: '2026-08-05T06:00:00.000Z',
+    },
+    {
+      timestamp: '2026-08-05T06:29:59.999Z',
+      expected: '2026-08-05T06:00:00.000Z',
+    },
+    {
+      timestamp: '2026-08-05T06:30:00.000Z',
+      expected: '2026-08-05T07:00:00.000Z',
+    },
+    {
+      timestamp: '2026-08-05T06:59:59.999Z',
+      expected: '2026-08-05T07:00:00.000Z',
+    },
+  ])('rounds $timestamp to $expected', ({ timestamp, expected }) => {
+    expect(roundToClosestHour(timestamp)).toBe(expected)
+  })
+
+  it('rounds across midnight', () => {
+    expect(roundToClosestHour('2026-08-05T23:45:00.000Z')).toBe(
+      '2026-08-06T00:00:00.000Z',
+    )
+  })
+
+  it('rounds across the end of a month', () => {
+    expect(roundToClosestHour('2026-08-31T23:45:00.000Z')).toBe(
+      '2026-09-01T00:00:00.000Z',
+    )
+  })
+
+  it('rounds across the end of a year', () => {
+    expect(roundToClosestHour('2026-12-31T23:45:00.000Z')).toBe(
+      '2027-01-01T00:00:00.000Z',
+    )
+  })
+
+  it('normalizes timestamps with a timezone offset to UTC', () => {
+    expect(roundToClosestHour('2026-08-05T08:20:00.000+02:00')).toBe(
+      '2026-08-05T06:00:00.000Z',
+    )
+  })
+
+  it.each(['', 'invalid', 'not-a-timestamp', '2026-99-99T99:99:99.999Z'])(
+    'throws for invalid timestamp %j',
+    (timestamp) => {
+      expect(() => roundToClosestHour(timestamp)).toThrow(TypeError)
+      expect(() => roundToClosestHour(timestamp)).toThrow(
+        `Invalid timestamp: "${timestamp}"`,
+      )
+    },
+  )
 })

--- a/test/unit/shared/utils/dates.test.ts
+++ b/test/unit/shared/utils/dates.test.ts
@@ -172,12 +172,9 @@ describe('roundToClosestHour', () => {
   })
 
   it.each(['', 'invalid', 'not-a-timestamp', '2026-99-99T99:99:99.999Z'])(
-    'throws for invalid timestamp %j',
+    'returns the original value for invalid timestamp %j',
     (timestamp) => {
-      expect(() => roundToClosestHour(timestamp)).toThrow(TypeError)
-      expect(() => roundToClosestHour(timestamp)).toThrow(
-        `Invalid timestamp: "${timestamp}"`,
-      )
+      expect(roundToClosestHour(timestamp)).toEqual(timestamp)
     },
   )
 })


### PR DESCRIPTION
This rounds timestamps for the hourly chart to the closest hour.

<img width="770" height="454" alt="image" src="https://github.com/user-attachments/assets/e7a8639e-419b-4a17-a20c-8b9f71a80102" />

This also fixes the hydration problem of the weekly bar chart in the lab page (hopefully).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved report loading so content begins loading as it approaches the visible area.

* **Bug Fixes**
  * Improved hourly scan statistics by consistently rounding timestamps to the nearest hour.
  * Added handling for timestamps crossing midnight, month, and year boundaries, including timezone offsets.
  * Preserved invalid timestamps without altering their values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->