### PR TITLE
fix(gh-app): request hang in CI without fallback response

### DIFF
--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -320,35 +320,39 @@ export default defineEventHandler(async (event) => {
 
     checkRunSettled = true
 
-    for (let attempt = 0; attempt < 2; attempt++) {
-      try {
-        await octokit.rest.checks.update({
-          owner,
-          repo,
-          check_run_id: checkRunId,
-          status: 'completed',
-          conclusion,
-          completed_at: new Date().toISOString(),
-          details_url: `https://agentscan.tools/user/${username}`,
-          output: { title, summary },
-        })
-        return
-      } catch {
-        // retry once, then give up
-      }
+    try {
+      await octokit.rest.checks.update({
+        owner,
+        repo,
+        check_run_id: checkRunId,
+        status: 'completed',
+        conclusion,
+        completed_at: new Date().toISOString(),
+        details_url: `https://agentscan.tools/user/${username}`,
+        output: { title, summary },
+      })
+    } catch (err: unknown) {
+      console.error(
+        `Failed to complete check run ${checkRunId} on ${owner}/${repo}:`,
+        err,
+      )
+      checkRunSettled = false
     }
   }
 
-  const deadline = checkRunId
-    ? setTimeout(() => {
-        void completeCheckRun(
-          'neutral',
-          'Analysis timed out',
-          'AgentScan did not finish analyzing this contributor in time. Re-run this check or reopen the pull request to try again.',
-          { fallback: true },
-        )
-      }, CHECK_RUN_DEADLINE_MS)
-    : undefined
+  // In case this takes too long, we're gonna timeout the process
+  let deadline: NodeJS.Timeout | undefined
+
+  if (checkRunId) {
+    deadline = setTimeout(() => {
+      completeCheckRun(
+        'neutral',
+        'Analysis timed out',
+        'AgentScan did not finish analyzing this contributor in time. Re-run this check or reopen the pull request to try again.',
+        { fallback: true },
+      )
+    }, CHECK_RUN_DEADLINE_MS)
+  }
 
   try {
     if (isPR && !repoConfig.scan['pull-requests']) {
@@ -459,9 +463,6 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    // Posted before any early return: the honeypot exists precisely to catch
-    // the accounts that the activity heuristics read as organic.
-    //
     // `mode` deliberately does not apply here. The bait is a comment: there
     // is no honeypot without one.
     if (repoConfig.honeypot && !shouldAutoClose) {

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -306,38 +306,55 @@ export default defineEventHandler(async (event) => {
 
   type CheckConclusion = 'success' | 'action_required' | 'failure' | 'neutral'
 
-  let checkRunSettled = false
+  // Resolves to whether the check run was settled. Held so a fallback can wait
+  // on a completion that is already in flight instead of racing it.
+  let completion: Promise<boolean> | undefined
 
-  const completeCheckRun = async (
+  const completeCheckRun = (
     conclusion: CheckConclusion,
     title: string,
     summary: string,
-    { fallback = false }: { fallback?: boolean } = {},
   ) => {
-    if (!checkRunId || (fallback && checkRunSettled)) {
-      return
+    if (!checkRunId) {
+      return Promise.resolve(true)
     }
 
-    checkRunSettled = true
+    const runId = checkRunId
 
-    try {
-      await octokit.rest.checks.update({
+    completion = octokit.rest.checks
+      .update({
         owner,
         repo,
-        check_run_id: checkRunId,
+        check_run_id: runId,
         status: 'completed',
         conclusion,
         completed_at: new Date().toISOString(),
         details_url: `https://agentscan.tools/user/${username}`,
         output: { title, summary },
       })
-    } catch (err: unknown) {
-      console.error(
-        `Failed to complete check run ${checkRunId} on ${owner}/${repo}:`,
-        err,
-      )
-      checkRunSettled = false
+      .then(() => true)
+      .catch((err: unknown) => {
+        console.error(
+          `Failed to complete check run ${runId} on ${owner}/${repo}:`,
+          err,
+        )
+        return false
+      })
+
+    return completion
+  }
+
+  // Last resort: only conclude the run if no other completion managed to.
+  const completeCheckRunIfUnsettled = async (
+    conclusion: CheckConclusion,
+    title: string,
+    summary: string,
+  ) => {
+    if (await completion) {
+      return
     }
+
+    await completeCheckRun(conclusion, title, summary)
   }
 
   // In case this takes too long, we're gonna timeout the process
@@ -345,11 +362,10 @@ export default defineEventHandler(async (event) => {
 
   if (checkRunId) {
     deadline = setTimeout(() => {
-      completeCheckRun(
+      completeCheckRunIfUnsettled(
         'neutral',
         'Analysis timed out',
         'AgentScan did not finish analyzing this contributor in time. Re-run this check or reopen the pull request to try again.',
-        { fallback: true },
       )
     }, CHECK_RUN_DEADLINE_MS)
   }
@@ -676,11 +692,10 @@ export default defineEventHandler(async (event) => {
 
     // Catches any exit that reached neither a conclusion nor the catch above —
     // an early return added later, or a non-Error thrown past it.
-    await completeCheckRun(
+    await completeCheckRunIfUnsettled(
       'neutral',
       'Analysis incomplete',
       'AgentScan did not produce a result for this contributor.',
-      { fallback: true },
     )
   }
 })

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -306,55 +306,43 @@ export default defineEventHandler(async (event) => {
 
   type CheckConclusion = 'success' | 'action_required' | 'failure' | 'neutral'
 
-  // Resolves to whether the check run was settled. Held so a fallback can wait
-  // on a completion that is already in flight instead of racing it.
-  let completion: Promise<boolean> | undefined
+  // The check run gets a result only once. The first call below wins, and any
+  // later one does nothing, so the timeout and the finally block can safely try
+  // without overwriting a real result.
+  let isCheckRunSettled = false
 
-  const completeCheckRun = (
+  const completeCheckRun = async (
     conclusion: CheckConclusion,
     title: string,
     summary: string,
   ) => {
-    if (!checkRunId) {
-      return Promise.resolve(true)
+    if (!checkRunId || isCheckRunSettled) {
+      return
     }
 
-    const runId = checkRunId
+    // Set before the request, not after, so that a call arriving while this one
+    // is still waiting for GitHub skips instead of sending a second result.
+    isCheckRunSettled = true
 
-    completion = octokit.rest.checks
-      .update({
+    try {
+      await octokit.rest.checks.update({
         owner,
         repo,
-        check_run_id: runId,
+        check_run_id: checkRunId,
         status: 'completed',
         conclusion,
         completed_at: new Date().toISOString(),
         details_url: `https://agentscan.tools/user/${username}`,
         output: { title, summary },
       })
-      .then(() => true)
-      .catch((err: unknown) => {
-        console.error(
-          `Failed to complete check run ${runId} on ${owner}/${repo}:`,
-          err,
-        )
-        return false
-      })
-
-    return completion
-  }
-
-  // Last resort: only conclude the run if no other completion managed to.
-  const completeCheckRunIfUnsettled = async (
-    conclusion: CheckConclusion,
-    title: string,
-    summary: string,
-  ) => {
-    if (await completion) {
-      return
+    } catch (err: unknown) {
+      // The check run still has no result, so let a later call try again.
+      isCheckRunSettled = false
+      console.error(
+        `Failed to complete check run ${checkRunId} on ${owner}/${repo}:`,
+        err,
+      )
     }
-
-    await completeCheckRun(conclusion, title, summary)
   }
 
   // In case this takes too long, we're gonna timeout the process
@@ -362,7 +350,7 @@ export default defineEventHandler(async (event) => {
 
   if (checkRunId) {
     deadline = setTimeout(() => {
-      completeCheckRunIfUnsettled(
+      completeCheckRun(
         'neutral',
         'Analysis timed out',
         'AgentScan did not finish analyzing this contributor in time. Re-run this check or reopen the pull request to try again.',
@@ -690,9 +678,9 @@ export default defineEventHandler(async (event) => {
   } finally {
     clearTimeout(deadline)
 
-    // Catches any exit that reached neither a conclusion nor the catch above —
-    // an early return added later, or a non-Error thrown past it.
-    await completeCheckRunIfUnsettled(
+    // Safety net: if the code above returned early without giving the check run
+    // a result, close it here so it never stays stuck as "in progress".
+    await completeCheckRun(
       'neutral',
       'Analysis incomplete',
       'AgentScan did not produce a result for this contributor.',

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -28,6 +28,10 @@ import {
   isOwnComment,
 } from './_honeypot'
 
+// Netlify's synchronous function timeout is 10s. Leave room to conclude the
+// check run before the process is killed.
+const CHECK_RUN_DEADLINE_MS = 8_000
+
 type AutomationListItem = {
   username: string
   reason: string
@@ -300,60 +304,80 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  type CheckConclusion = 'success' | 'action_required' | 'failure'
+  type CheckConclusion = 'success' | 'action_required' | 'failure' | 'neutral'
+
+  let checkRunSettled = false
 
   const completeCheckRun = async (
     conclusion: CheckConclusion,
     title: string,
     summary: string,
+    { fallback = false }: { fallback?: boolean } = {},
   ) => {
-    if (!checkRunId) {
+    if (!checkRunId || (fallback && checkRunSettled)) {
       return
     }
-    await octokit.rest.checks
-      .update({
-        owner,
-        repo,
-        check_run_id: checkRunId,
-        status: 'completed',
-        conclusion,
-        completed_at: new Date().toISOString(),
-        details_url: `https://agentscan.tools/user/${username}`,
-        output: { title, summary },
-      })
-      .catch(() => {
-        // check run update failed
-      })
+
+    checkRunSettled = true
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        await octokit.rest.checks.update({
+          owner,
+          repo,
+          check_run_id: checkRunId,
+          status: 'completed',
+          conclusion,
+          completed_at: new Date().toISOString(),
+          details_url: `https://agentscan.tools/user/${username}`,
+          output: { title, summary },
+        })
+        return
+      } catch {
+        // retry once, then give up
+      }
+    }
   }
 
-  if (isPR && !repoConfig.scan['pull-requests']) {
-    await completeCheckRun(
-      'success',
-      'Analysis skipped',
-      'PR scanning is disabled for this repository.',
-    )
-    return { ok: true }
-  }
-
-  if (isIssue && !repoConfig.scan.issues) {
-    return { ok: true }
-  }
-
-  if (
-    repoConfig['allowed-users'].includes(username) ||
-    isKnownBot(username) ||
-    (authorAssociation &&
-      repoConfig['trusted-author-associations'].includes(authorAssociation))
-  ) {
-    await completeCheckRun(
-      'success',
-      'Analysis skipped',
-      'This contributor is exempt from analysis (allow-listed, a known automation, or a trusted author association).',
-    )
-    return { ok: true }
-  }
+  const deadline = checkRunId
+    ? setTimeout(() => {
+        void completeCheckRun(
+          'neutral',
+          'Analysis timed out',
+          'AgentScan did not finish analyzing this contributor in time. Re-run this check or reopen the pull request to try again.',
+          { fallback: true },
+        )
+      }, CHECK_RUN_DEADLINE_MS)
+    : undefined
 
   try {
+    if (isPR && !repoConfig.scan['pull-requests']) {
+      await completeCheckRun(
+        'success',
+        'Analysis skipped',
+        'PR scanning is disabled for this repository.',
+      )
+      return { ok: true }
+    }
+
+    if (isIssue && !repoConfig.scan.issues) {
+      return { ok: true }
+    }
+
+    if (
+      repoConfig['allowed-users'].includes(username) ||
+      isKnownBot(username) ||
+      (authorAssociation &&
+        repoConfig['trusted-author-associations'].includes(authorAssociation))
+    ) {
+      await completeCheckRun(
+        'success',
+        'Analysis skipped',
+        'This contributor is exempt from analysis (allow-listed, a known automation, or a trusted author association).',
+      )
+      return { ok: true }
+    }
+
     const { data: user } = await octokit.rest.users.getByUsername({ username })
 
     const responses = await Promise.all(
@@ -646,5 +670,16 @@ export default defineEventHandler(async (event) => {
       'AgentScan encountered an error while analyzing this contributor.',
     )
     throw err
+  } finally {
+    clearTimeout(deadline)
+
+    // Catches any exit that reached neither a conclusion nor the catch above —
+    // an early return added later, or a non-Error thrown past it.
+    await completeCheckRun(
+      'neutral',
+      'Analysis incomplete',
+      'AgentScan did not produce a result for this contributor.',
+      { fallback: true },
+    )
   }
 })

--- a/test/unit/server/api/webhook/github.post.test.ts
+++ b/test/unit/server/api/webhook/github.post.test.ts
@@ -1718,39 +1718,40 @@ describe('GitHub Webhook Handler', () => {
       expect(mockInstallationOctokit.rest.checks.update).not.toHaveBeenCalled()
     })
 
-    it('retries the completion once when the check run update fails transiently', async () => {
-      mockInstallationOctokit.rest.checks.update
-        .mockRejectedValueOnce(new Error('502 Bad Gateway'))
-        .mockResolvedValueOnce({})
-
-      await handler(MOCK_EVENT)
-
-      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
-        2,
-      )
-    })
-
-    it('does not throw when both completion attempts fail', async () => {
+    it('does not throw when the check run completion fails', async () => {
       mockInstallationOctokit.rest.checks.update.mockRejectedValue(
         new Error('502 Bad Gateway'),
       )
 
       await expect(handler(MOCK_EVENT)).resolves.toMatchObject({ ok: true })
+      // No retry of the real conclusion, but the run must not be left at
+      // `in_progress`: the guard concludes it as neutral instead.
       expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
         2,
+      )
+      expect(
+        mockInstallationOctokit.rest.checks.update,
+      ).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          conclusion: 'neutral',
+          output: expect.objectContaining({ title: 'Analysis incomplete' }),
+        }),
       )
     })
 
     it('concludes the check run as neutral when the analysis outruns the deadline', async () => {
       vi.useFakeTimers()
 
-      // Never settles: stands in for a scan slow enough to be killed by the
-      // function timeout before it can conclude the run itself.
+      // Stays pending past the deadline: stands in for a scan slow enough to be
+      // killed by the function timeout before it can conclude the run itself.
+      let resolveUser: (value: unknown) => void = () => {}
       mockInstallationOctokit.rest.users.getByUsername.mockReturnValue(
-        new Promise(() => {}),
+        new Promise((resolve) => {
+          resolveUser = resolve
+        }),
       )
 
-      void handler(MOCK_EVENT)
+      const pending = handler(MOCK_EVENT)
 
       // Let the handler reach the deadline setup before the timer fires.
       await vi.advanceTimersByTimeAsync(8_000)
@@ -1763,6 +1764,13 @@ describe('GitHub Webhook Handler', () => {
           output: expect.objectContaining({ title: 'Analysis timed out' }),
         }),
       )
+
+      // Let the handler run its cleanup before handing the clock back, so no
+      // in-flight work leaks into the next test.
+      resolveUser({
+        data: { public_repos: 10, created_at: '2020-01-01T00:00:00Z' },
+      })
+      await pending
 
       vi.useRealTimers()
     })

--- a/test/unit/server/api/webhook/github.post.test.ts
+++ b/test/unit/server/api/webhook/github.post.test.ts
@@ -1717,5 +1717,70 @@ describe('GitHub Webhook Handler', () => {
       expect(result).toMatchObject({ ok: true })
       expect(mockInstallationOctokit.rest.checks.update).not.toHaveBeenCalled()
     })
+
+    it('retries the completion once when the check run update fails transiently', async () => {
+      mockInstallationOctokit.rest.checks.update
+        .mockRejectedValueOnce(new Error('502 Bad Gateway'))
+        .mockResolvedValueOnce({})
+
+      await handler(MOCK_EVENT)
+
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
+        2,
+      )
+    })
+
+    it('does not throw when both completion attempts fail', async () => {
+      mockInstallationOctokit.rest.checks.update.mockRejectedValue(
+        new Error('502 Bad Gateway'),
+      )
+
+      await expect(handler(MOCK_EVENT)).resolves.toMatchObject({ ok: true })
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
+        2,
+      )
+    })
+
+    it('concludes the check run as neutral when the analysis outruns the deadline', async () => {
+      vi.useFakeTimers()
+
+      // Never settles: stands in for a scan slow enough to be killed by the
+      // function timeout before it can conclude the run itself.
+      mockInstallationOctokit.rest.users.getByUsername.mockReturnValue(
+        new Promise(() => {}),
+      )
+
+      void handler(MOCK_EVENT)
+
+      // Let the handler reach the deadline setup before the timer fires.
+      await vi.advanceTimersByTimeAsync(8_000)
+
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          check_run_id: 555,
+          status: 'completed',
+          conclusion: 'neutral',
+          output: expect.objectContaining({ title: 'Analysis timed out' }),
+        }),
+      )
+
+      vi.useRealTimers()
+    })
+
+    it('does not conclude the check run twice when the scan finishes before the deadline', async () => {
+      vi.useFakeTimers()
+
+      await handler(MOCK_EVENT)
+      await vi.advanceTimersByTimeAsync(30_000)
+
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
+        1,
+      )
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({ conclusion: 'success' }),
+      )
+
+      vi.useRealTimers()
+    })
   })
 })


### PR DESCRIPTION
Not resolving the request was causing CI to keep waiting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - GitHub check runs now complete reliably when analysis times out or completion updates fail.
  - Added an 8-second deadline with a neutral fallback result and timeout messaging.
  - Prevented duplicate check-run completions.
  - Ensured unfinished checks are marked incomplete when processing ends unexpectedly.

- **Tests**
  - Added coverage for neutral fallbacks, timeouts, failed completion updates, and duplicate-completion prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->