### PR TITLE
fix: improve timezone selector

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -521,7 +521,7 @@ const showTzSelector = shallowRef(false)
       <div ref="chartContainer" class="w-full">
         <VueUiXy v-if="hasStableChartWidth" ref="chartRef" :dataset :config>
           <template #svg="{ svg }">
-            <g aria-hidden="true" pointer-events="none" v-if="showTzSelector">
+            <g v-if="showTzSelector" aria-hidden="true" pointer-events="none">
               <rect
                 v-for="rect in getFogOfSleep(svg)"
                 :key="rect.id"

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -7,7 +7,7 @@ import {
   type VueUiXySvgSlotProps,
 } from 'vue-data-ui/vue-ui-xy'
 import { useTooltipPosition } from 'vue-data-ui/composables'
-import { useElementSize } from '@vueuse/core'
+import { useElementSize, usePreferredDark } from '@vueuse/core'
 import dayjs, { type Dayjs } from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
@@ -23,6 +23,7 @@ dayjs.extend(timezone)
 import('vue-data-ui/style.css')
 
 const { data } = useEcosystemHealthHourly()
+const isDarkMode = usePreferredDark()
 
 const scanTimes = computed(() => data.value?.scanTimes ?? [])
 const countsByScanTime = computed(() => data.value?.countsByScanTime)
@@ -313,7 +314,7 @@ type FogOfSleepRect = {
   height: number
 }
 
-const selectedTimezoneId = ref<TimezoneId>('UTC+00:00')
+const selectedTimezoneId = ref<TimezoneId>('UTC+02:00')
 const workHours = ref<TimezoneWorkHours>({})
 
 function getTimeParts(value: string) {
@@ -459,7 +460,7 @@ function getFogOfSleep(svg: VueUiXySvgSlotProps['svg']): FogOfSleepRect[] {
   const left = svg.drawingArea.left
   const right = svg.drawingArea.right
   const top = svg.drawingArea.top
-  const bottom = svg.drawingArea.bottom
+  const bottom = svg.drawingArea.bottom + 20 // additional height to cover time labels
   const height = Math.max(0, bottom - top)
   const startX = Math.min(right, Math.max(left, startPlot.x))
   const endX = Math.min(right, Math.max(left, endPlot.x))
@@ -497,6 +498,8 @@ function getFogOfSleep(svg: VueUiXySvgSlotProps['svg']): FogOfSleepRect[] {
     (rect): rect is FogOfSleepRect => rect !== null,
   )
 }
+
+const showTzSelector = shallowRef(false)
 </script>
 
 <template>
@@ -518,7 +521,7 @@ function getFogOfSleep(svg: VueUiXySvgSlotProps['svg']): FogOfSleepRect[] {
       <div ref="chartContainer" class="w-full">
         <VueUiXy v-if="hasStableChartWidth" ref="chartRef" :dataset :config>
           <template #svg="{ svg }">
-            <g aria-hidden="true" pointer-events="none">
+            <g aria-hidden="true" pointer-events="none" v-if="showTzSelector">
               <rect
                 v-for="rect in getFogOfSleep(svg)"
                 :key="rect.id"
@@ -526,8 +529,8 @@ function getFogOfSleep(svg: VueUiXySvgSlotProps['svg']): FogOfSleepRect[] {
                 :y="rect.y"
                 :width="rect.width"
                 :height="rect.height"
-                :fill="colors.bg"
-                fill-opacity="0.4"
+                fill="#0b0b0b"
+                :fill-opacity="isDarkMode ? 0.3 : 0.1"
                 style="transition: all 0.2s"
               />
             </g>
@@ -672,12 +675,41 @@ function getFogOfSleep(svg: VueUiXySvgSlotProps['svg']): FogOfSleepRect[] {
       </div>
     </ClientOnly>
 
-    <CommonTimezoneWorkHoursSelector
-      v-if="hasData"
-      v-model="workHours"
-      v-model:timezone="selectedTimezoneId"
-      class="mx-auto mb-5"
-    />
+    <template v-if="hasData">
+      <div
+        class="mx-auto mb-5 overflow-hidden rounded-lg border border-current/10 transition-colors"
+      >
+        <label
+          class="flex cursor-pointer items-center justify-between gap-4 px-3 py-2.5 transition-colors hover:bg-current/[0.03]"
+        >
+          <div class="min-w-0">
+            <span class="block text-sm font-medium text-inherit">
+              Show activity hours
+            </span>
+
+            <span class="mt-0.5 block text-xs text-gh-muted">
+              Display activity hours by a selected timezone
+            </span>
+          </div>
+
+          <input
+            v-model="showTzSelector"
+            type="checkbox"
+            class="h-4 w-4 shrink-0 cursor-pointer accent-current"
+          />
+        </label>
+
+        <div
+          v-show="showTzSelector"
+          class="border-t border-current/10 px-3 py-3"
+        >
+          <CommonTimezoneWorkHoursSelector
+            v-model="workHours"
+            v-model:timezone="selectedTimezoneId"
+          />
+        </div>
+      </div>
+    </template>
   </section>
 </template>
 

--- a/app/components/Common/TimezoneWorkHoursSelector.vue
+++ b/app/components/Common/TimezoneWorkHoursSelector.vue
@@ -286,40 +286,6 @@ function formatOffset(offsetMinutes: number): string {
   return offset === '+00:00' ? 'UTC±00:00' : `UTC${offset}`
 }
 
-function formatUtcTime(
-  localTime: string,
-  offsetMinutes: number,
-  nextLocalDay = false,
-): string {
-  const [hour, minute] = localTime.split(':').map(Number)
-
-  const referenceDay = dayjs.utc('2000-01-02T00:00:00Z')
-
-  const localDateTime = referenceDay
-    .add(nextLocalDay ? 1 : 0, 'day')
-    .hour(hour!)
-    .minute(minute!)
-
-  const utcDateTime = localDateTime.subtract(offsetMinutes, 'minute')
-
-  const dayDifference = utcDateTime
-    .startOf('day')
-    .diff(referenceDay.startOf('day'), 'day')
-
-  let dayLabel = ''
-
-  if (dayDifference === -1) {
-    dayLabel = ' · previous day'
-  } else if (dayDifference === 1) {
-    dayLabel = ' · next day'
-  } else if (dayDifference !== 0) {
-    const prefix = dayDifference > 0 ? '+' : ''
-    dayLabel = ` · ${prefix}${dayDifference} days`
-  }
-
-  return `${utcDateTime.format('HH:mm')} UTC${dayLabel}`
-}
-
 watch(
   model,
   (value) => {
@@ -358,12 +324,11 @@ watch(
 </script>
 
 <template>
-  <section
-    class="w-full rounded-lg border border-current/10 bg-transparent p-3"
-    aria-label="Work hours by timezone"
-  >
-    <div class="grid grid-cols-1 gap-2.5 sm:grid-cols-2 lg:grid-cols-4">
-      <label class="grid min-w-0 gap-1 sm:col-span-2">
+  <section class="w-full" aria-label="Work hours by timezone">
+    <div class="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap">
+      <label
+        class="flex min-w-0 w-full flex-col gap-1 lg:w-[calc(50%_-_0.3125rem)]"
+      >
         <span
           class="text-[11px] font-medium uppercase tracking-wide text-gh-muted"
         >
@@ -385,32 +350,13 @@ watch(
         </select>
       </label>
 
-      <label class="grid min-w-0 gap-1">
+      <label
+        class="flex min-w-0 w-full flex-col gap-1 sm:w-[calc(50%_-_0.3125rem)] lg:w-[calc(25%_-_0.46875rem)]"
+      >
         <span
           class="text-[11px] font-medium uppercase tracking-wide text-gh-muted"
         >
-          Work starts
-        </span>
-
-        <select
-          v-model="selectedStart"
-          class="min-w-0 w-full rounded-md border border-current/20 bg-transparent px-2.5 py-1.5 text-sm tabular-nums text-inherit outline-none transition-colors hover:border-current/30 focus:border-current/40 focus:ring-2 focus:ring-current/10"
-        >
-          <option
-            v-for="time in timeOptions"
-            :key="time.value"
-            :value="time.value"
-          >
-            {{ time.label }}
-          </option>
-        </select>
-      </label>
-
-      <label class="grid min-w-0 gap-1">
-        <span
-          class="text-[11px] font-medium uppercase tracking-wide text-gh-muted"
-        >
-          Work ends
+          Sleep starts
         </span>
 
         <select
@@ -426,35 +372,29 @@ watch(
           </option>
         </select>
       </label>
-    </div>
 
-    <div
-      class="mt-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-current/10 pt-2 text-xs text-gh-muted"
-    >
-      <span class="min-w-0 truncate">
-        {{ selectedTimezone.examples }}
-      </span>
-
-      <div class="flex flex-wrap items-center gap-x-3 gap-y-1 tabular-nums">
-        <span class="text-inherit">
-          {{ selectedStart }}–{{ selectedEnd }}
-          <span v-if="isOvernight">(+1 day)</span>
+      <label
+        class="flex min-w-0 w-full flex-col gap-1 sm:w-[calc(50%_-_0.3125rem)] lg:w-[calc(25%_-_0.46875rem)]"
+      >
+        <span
+          class="text-[11px] font-medium uppercase tracking-wide text-gh-muted"
+        >
+          Sleep ends
         </span>
 
-        <span aria-hidden="true" class="hidden opacity-40 sm:inline">·</span>
-
-        <span>
-          {{ formatUtcTime(selectedStart, selectedTimezone.offsetMinutes) }}
-          →
-          {{
-            formatUtcTime(
-              selectedEnd,
-              selectedTimezone.offsetMinutes,
-              isOvernight,
-            )
-          }}
-        </span>
-      </div>
+        <select
+          v-model="selectedStart"
+          class="min-w-0 w-full rounded-md border border-current/20 bg-transparent px-2.5 py-1.5 text-sm tabular-nums text-inherit outline-none transition-colors hover:border-current/30 focus:border-current/40 focus:ring-2 focus:ring-current/10"
+        >
+          <option
+            v-for="time in timeOptions"
+            :key="time.value"
+            :value="time.value"
+          >
+            {{ time.label }}
+          </option>
+        </select>
+      </label>
     </div>
   </section>
 </template>

--- a/app/components/Common/TimezoneWorkHoursSelector.vue
+++ b/app/components/Common/TimezoneWorkHoursSelector.vue
@@ -184,13 +184,6 @@ const timeOptions = Array.from({ length: 24 }, (_, hour) => {
   }
 })
 
-const selectedTimezone = computed(() => {
-  return (
-    TIMEZONES.find((timezone) => timezone.id === selectedTimezoneId.value) ??
-    TIMEZONES[12]
-  )
-})
-
 const selectedWorkHours = computed<WorkHours>(() => {
   return (
     model.value?.[selectedTimezoneId.value] ?? {
@@ -217,10 +210,6 @@ const selectedEnd = computed({
   set(value: string): void {
     updateWorkHour('end', value)
   },
-})
-
-const isOvernight = computed(() => {
-  return selectedEnd.value <= selectedStart.value
 })
 
 function isValidTime(value: unknown): value is string {


### PR DESCRIPTION
Improvements:

- use UTC+2 by default on load
- add a toggle, unchecked by default, to display the tz selector
- simplify the tz selector, also with more understandable labels
- improve the looks in light mode

<img width="731" height="597" alt="image" src="https://github.com/user-attachments/assets/b92377f2-4c39-466e-b708-d6718e23b930" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark-mode support for the hourly activity chart.
  * Added an optional timezone activity overlay with a toggle.
  * Moved timezone controls into a collapsible panel shown when chart data is available.

* **Improvements**
  * Updated the default timezone to UTC+02:00.
  * Improved overlay coverage and appearance across chart labels and themes.
  * Simplified the sleep schedule selector and refreshed its layout and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->