### PR TITLE
feat(hourly-window): add empty bucket when no entries

### DIFF
--- a/server/api/health/hourly-window.get.ts
+++ b/server/api/health/hourly-window.get.ts
@@ -1,5 +1,12 @@
 import { unpack } from '~~/shared/utils/compactor'
-import { getClassificationStatsByScanTime } from '~~/shared/utils/count-classification-by-date'
+import {
+  fillEmptyHourlyBuckets,
+  getClassificationStatsByScanTime,
+} from '~~/shared/utils/count-classification-by-date'
+
+// Same hours from the workflow script
+// @todo move to a shared file and make it default without options
+const WINDOW_MAX_HOURS = 25
 
 export default defineEventHandler(async () => {
   try {
@@ -22,7 +29,12 @@ export default defineEventHandler(async () => {
     const mixedPercentages: number[] = []
     const organicPercentages: number[] = []
 
-    const countsByScanTime = getClassificationStatsByScanTime(results)
+    // An hour with no PR opened writes no row at all, so it has to be
+    // added as an empty bucket instead of being skipped by the chart.
+    const countsByScanTime = fillEmptyHourlyBuckets({
+      countsByHour: getClassificationStatsByScanTime(results),
+      maxHours: WINDOW_MAX_HOURS,
+    })
     const scanTimes = Object.keys(countsByScanTime).sort()
 
     scanTimes.forEach((scanTime) => {

--- a/shared/utils/count-classification-by-date.ts
+++ b/shared/utils/count-classification-by-date.ts
@@ -130,6 +130,31 @@ export function getClassificationStatsByScanTime(
 
 const MILLISECONDS_PER_HOUR = 60 * 60 * 1000
 
+// The clock hour a timestamp belongs to, so a scan time and the placeholder
+// standing in for it can never end up under two different keys.
+function getHourTime(time: number): number {
+  return Math.floor(time / MILLISECONDS_PER_HOUR) * MILLISECONDS_PER_HOUR
+}
+
+function mergeClassificationStats(
+  current: ClassificationStats,
+  next: ClassificationStats,
+): ClassificationStats {
+  const merged = createEmptyClassificationStats()
+
+  CLASSIFICATION_CATEGORIES.forEach((category) => {
+    merged[category].count = current[category].count + next[category].count
+  })
+
+  merged.createdAt =
+    [current.createdAt, next.createdAt]
+      .filter((createdAt): createdAt is string => Boolean(createdAt))
+      .sort()
+      .at(0) ?? null
+
+  return applyClassificationPercentages(merged)
+}
+
 export function fillEmptyHourlyBuckets({
   countsByHour,
   maxHours,
@@ -152,31 +177,55 @@ export function fillEmptyHourlyBuckets({
     return countsByHour
   }
 
+  const firstHourTime = getHourTime(firstTime)
+  const lastHourTime = getHourTime(lastTime)
+
   const startTime =
     maxHours && maxHours > 0
-      ? Math.max(firstTime, lastTime - (maxHours - 1) * MILLISECONDS_PER_HOUR)
-      : firstTime
-
-  const result: GetClassificationStatsByDateResults = {}
-
-  for (let time = startTime; time <= lastTime; time += MILLISECONDS_PER_HOUR) {
-    result[new Date(time).toISOString()] = applyClassificationPercentages(
-      createEmptyClassificationStats(),
-    )
-  }
+      ? Math.max(
+          firstHourTime,
+          lastHourTime - (maxHours - 1) * MILLISECONDS_PER_HOUR,
+        )
+      : firstHourTime
 
   // Scan times that don't sit exactly on the hourly grid still belong to the
-  // window, so they overwrite the placeholders rather than being dropped.
+  // window, so they collapse onto their clock hour rather than being dropped
+  // next to the placeholder for that same hour.
+  const recorded: GetClassificationStatsByDateResults = {}
+
   hours.forEach((hour) => {
     const counts = countsByHour[hour]
     const time = new Date(hour).getTime()
 
-    if (!counts || Number.isNaN(time) || time < startTime) {
+    if (!counts || Number.isNaN(time)) {
       return
     }
 
-    result[hour] = counts
+    const hourTime = getHourTime(time)
+
+    if (hourTime < startTime) {
+      return
+    }
+
+    const key = new Date(hourTime).toISOString()
+    const current = recorded[key]
+
+    recorded[key] = current ? mergeClassificationStats(current, counts) : counts
   })
+
+  const result: GetClassificationStatsByDateResults = {}
+
+  for (
+    let time = startTime;
+    time <= lastHourTime;
+    time += MILLISECONDS_PER_HOUR
+  ) {
+    const key = new Date(time).toISOString()
+
+    result[key] =
+      recorded[key] ??
+      applyClassificationPercentages(createEmptyClassificationStats())
+  }
 
   return result
 }

--- a/shared/utils/count-classification-by-date.ts
+++ b/shared/utils/count-classification-by-date.ts
@@ -128,6 +128,59 @@ export function getClassificationStatsByScanTime(
   return getClassificationStatsByBucket(data, (createdAt) => createdAt)
 }
 
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000
+
+export function fillEmptyHourlyBuckets({
+  countsByHour,
+  maxHours,
+}: {
+  countsByHour: GetClassificationStatsByDateResults
+  maxHours?: number
+}): GetClassificationStatsByDateResults {
+  const hours = Object.keys(countsByHour).sort()
+  const firstHour = hours.at(0)
+  const lastHour = hours.at(-1)
+
+  if (!firstHour || !lastHour) {
+    return {}
+  }
+
+  const firstTime = new Date(firstHour).getTime()
+  const lastTime = new Date(lastHour).getTime()
+
+  if (Number.isNaN(firstTime) || Number.isNaN(lastTime)) {
+    return countsByHour
+  }
+
+  const startTime =
+    maxHours && maxHours > 0
+      ? Math.max(firstTime, lastTime - (maxHours - 1) * MILLISECONDS_PER_HOUR)
+      : firstTime
+
+  const result: GetClassificationStatsByDateResults = {}
+
+  for (let time = startTime; time <= lastTime; time += MILLISECONDS_PER_HOUR) {
+    result[new Date(time).toISOString()] = applyClassificationPercentages(
+      createEmptyClassificationStats(),
+    )
+  }
+
+  // Scan times that don't sit exactly on the hourly grid still belong to the
+  // window, so they overwrite the placeholders rather than being dropped.
+  hours.forEach((hour) => {
+    const counts = countsByHour[hour]
+    const time = new Date(hour).getTime()
+
+    if (!counts || Number.isNaN(time) || time < startTime) {
+      return
+    }
+
+    result[hour] = counts
+  })
+
+  return result
+}
+
 function getTotalClassificationCount(
   counts: ClassificationStats | undefined,
 ): number | null {
@@ -160,7 +213,7 @@ function getCategoryPercentageComparison({
   category: EcosystemHealthCategory
   lastDate: string | undefined
   previousDate: string | undefined
-  countsByDate: getClassificationStatsByDateResults
+  countsByDate: GetClassificationStatsByDateResults
 }): CategoryPercentageComparison {
   const previousCounts = previousDate ? countsByDate[previousDate] : undefined
   const lastCounts = lastDate ? countsByDate[lastDate] : undefined
@@ -295,7 +348,7 @@ function sumClassificationCountsByDates({
   countsByDate,
   dates,
 }: {
-  countsByDate: getClassificationStatsByDateResults
+  countsByDate: GetClassificationStatsByDateResults
   dates: Set<string>
 }): ClassificationStats {
   const result = createEmptyClassificationStats()

--- a/test/unit/shared/utils/count-classification-by-date.test.ts
+++ b/test/unit/shared/utils/count-classification-by-date.test.ts
@@ -4,10 +4,12 @@ import type {
   ClassificationMetric,
 } from '../../../../shared/utils/count-classification-by-date'
 import {
+  fillEmptyHourlyBuckets,
   getClassificationStatsByDate,
   getCategoryDeltas,
   getClassificationByDateChunks,
   getClassificationForPreviousDays,
+  getClassificationStatsByScanTime,
   getWeeklyClassification,
 } from '../../../../shared/utils/count-classification-by-date'
 import type { EcosystemHealthItem } from '../../../../shared/types/ecosystem-health'
@@ -758,5 +760,66 @@ describe('getWeeklyClassification', () => {
         percentage: 100,
       },
     })
+  })
+})
+
+describe('fillEmptyHourlyBuckets', () => {
+  it('returns an empty result when there is nothing to fill', () => {
+    expect(fillEmptyHourlyBuckets({ countsByHour: {} })).toEqual({})
+  })
+
+  it('reinstates hours that recorded no entry as empty buckets', () => {
+    const countsByHour = getClassificationStatsByScanTime([
+      createEcosystemHealthItem('2026-08-08T05:00:00.000Z', 90),
+      createEcosystemHealthItem('2026-08-08T08:00:00.000Z', 10),
+    ])
+
+    const result = fillEmptyHourlyBuckets({ countsByHour })
+
+    expect(Object.keys(result).sort()).toEqual([
+      '2026-08-08T05:00:00.000Z',
+      '2026-08-08T06:00:00.000Z',
+      '2026-08-08T07:00:00.000Z',
+      '2026-08-08T08:00:00.000Z',
+    ])
+
+    // Zeroed because there was nothing to classify, not because of a score.
+    expectClassificationCounts(result['2026-08-08T06:00:00.000Z']!, {
+      organic: { count: 0, trend: 0, percentage: 0 },
+      mixed: { count: 0, trend: 0, percentage: 0 },
+      automation: { count: 0, trend: 0, percentage: 0 },
+      total: { count: 0, trend: 0, percentage: 0 },
+    })
+  })
+
+  it('keeps the recorded buckets untouched', () => {
+    const countsByHour = getClassificationStatsByScanTime([
+      createEcosystemHealthItem('2026-08-08T05:00:00.000Z', 90),
+      createEcosystemHealthItem('2026-08-08T07:00:00.000Z', 10),
+    ])
+
+    const result = fillEmptyHourlyBuckets({ countsByHour })
+
+    expectClassificationCounts(result['2026-08-08T07:00:00.000Z']!, {
+      organic: { count: 0, trend: 0, percentage: 0 },
+      mixed: { count: 0, trend: 0, percentage: 0 },
+      automation: { count: 1, trend: 0, percentage: 100 },
+      total: { count: 1, trend: 0, percentage: 100 },
+    })
+  })
+
+  it('caps the timeline to maxHours counted back from the latest bucket', () => {
+    const countsByHour = getClassificationStatsByScanTime([
+      createEcosystemHealthItem('2026-08-08T01:00:00.000Z', 90),
+      createEcosystemHealthItem('2026-08-08T05:00:00.000Z', 90),
+    ])
+
+    const result = fillEmptyHourlyBuckets({ countsByHour, maxHours: 3 })
+
+    expect(Object.keys(result).sort()).toEqual([
+      '2026-08-08T03:00:00.000Z',
+      '2026-08-08T04:00:00.000Z',
+      '2026-08-08T05:00:00.000Z',
+    ])
   })
 })

--- a/test/unit/shared/utils/count-classification-by-date.test.ts
+++ b/test/unit/shared/utils/count-classification-by-date.test.ts
@@ -822,4 +822,43 @@ describe('fillEmptyHourlyBuckets', () => {
       '2026-08-08T05:00:00.000Z',
     ])
   })
+
+  it('keeps one bucket per clock hour when scan times drift off the hour', () => {
+    const countsByHour = getClassificationStatsByScanTime([
+      createEcosystemHealthItem('2026-08-08T05:00:12.000Z', 90),
+      createEcosystemHealthItem('2026-08-08T06:14:47.000Z', 10),
+      createEcosystemHealthItem('2026-08-08T06:41:03.000Z', 10),
+      createEcosystemHealthItem('2026-08-08T08:03:29.000Z', 50),
+    ])
+
+    const result = fillEmptyHourlyBuckets({ countsByHour })
+
+    expect(Object.keys(result).sort()).toEqual([
+      '2026-08-08T05:00:00.000Z',
+      '2026-08-08T06:00:00.000Z',
+      '2026-08-08T07:00:00.000Z',
+      '2026-08-08T08:00:00.000Z',
+    ])
+
+    // Both 06:xx scans belong to the same clock hour, so their counts add up
+    // instead of splitting into two buckets.
+    expectClassificationCounts(result['2026-08-08T06:00:00.000Z']!, {
+      organic: { count: 0, trend: 0, percentage: 0 },
+      mixed: { count: 0, trend: 0, percentage: 0 },
+      automation: { count: 2, trend: 0, percentage: 100 },
+      total: { count: 2, trend: 0, percentage: 100 },
+    })
+
+    expect(result['2026-08-08T06:00:00.000Z']!.createdAt).toBe(
+      '2026-08-08T06:14:47.000Z',
+    )
+
+    // The hour with no scan at all is still an empty placeholder.
+    expectClassificationCounts(result['2026-08-08T07:00:00.000Z']!, {
+      organic: { count: 0, trend: 0, percentage: 0 },
+      mixed: { count: 0, trend: 0, percentage: 0 },
+      automation: { count: 0, trend: 0, percentage: 0 },
+      total: { count: 0, trend: 0, percentage: 0 },
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trend and progression calculations now include missing hourly intervals with zero counts.
  * Hourly classification data is consistently completed across the relevant time window.
* **Tests**
  * Added coverage for empty results, missing hourly buckets, preserved scan data, and limited time windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->