### PR TITLE
fix: use inline styles for foreignObject child div

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -558,7 +558,13 @@ const showTzSelector = shallowRef(false)
                 :height="rect.height"
                 style="transition: all 0.2s"
               >
-                <div class="w-full h-full blurred"></div>
+                <div
+                  class="w-full h-full"
+                  style="
+                    backdrop-filter: blur(5px);
+                    -webkit-backdrop-filter: blur(5px);
+                  "
+                ></div>
               </foreignObject>
             </g>
           </template>
@@ -722,10 +728,5 @@ const showTzSelector = shallowRef(false)
 }
 :deep(.vue-ui-xy-svg) {
   overflow: visible; /** for last time label cropping issue  */
-}
-
-.blurred {
-  backdrop-filter: blur(5px);
-  -webkit-backdrop-filter: blur(5px);
 }
 </style>


### PR DESCRIPTION
Using a css class in a scoped style, for a div inside a foreignObject fails with unocss.
Inline styles ftw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the fog overlay’s blur rendering for a more consistent visual effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->