### PR TITLE
feat: improve hourly health warning icons

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
   scanTimes: string[]
   countsByScanTime: GetClassificationStatsByDateResults
   automationThreshold: number
+  mixedThreshold: number
 }>()
 
 const countsByScanTime = computed(() => props.countsByScanTime)
@@ -234,7 +235,8 @@ type PlotAlert = {
     x: number
     y: number
     absoluteIndex: number
-    isAlert: boolean
+    isAlertAutomation: boolean
+    isAlertMixed: boolean
   }>
 }
 
@@ -242,9 +244,16 @@ function isAlert(value: VueUiXyDatasetItem['series'][0], threshold: number) {
   return value != null && (value as number) > threshold
 }
 
-function getZapIconPath({ x, y }: { x: number; y: number }) {
+type Coordinates = { x: number; y: number }
+
+function getZapIconPath({ x, y }: Coordinates) {
   // ⚡ with relative coordinates from initial position
   return `M ${x} ${y} l 12 -17 l -6 0 l 3 -13 l -11 17 l 6 0 l -4 13`
+}
+
+function getWarningIconPath({ x, y }: Coordinates) {
+  // ⚠ with relative coordinates from initial position
+  return `m${x} ${y}l 0 5 m 0 -11 l -8 14 l 16 0 l -8 -14`
 }
 
 function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
@@ -257,12 +266,15 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
         return {
           ...plot,
           absoluteIndex,
-          isAlert:
+          isAlertAutomation:
             d.name === 'Automation' &&
             isAlert(
               d.absoluteValues[absoluteIndex]!,
               props.automationThreshold,
             ),
+          isAlertMixed:
+            d.name === 'Mixed' &&
+            isAlert(d.absoluteValues[absoluteIndex]!, props.mixedThreshold),
         }
       }),
     }
@@ -301,7 +313,7 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
                 :key="`${alerts.name}-${plot.absoluteIndex}`"
               >
                 <path
-                  v-show="plot.isAlert"
+                  v-show="plot.isAlertAutomation"
                   class="zap-icon"
                   :d="
                     getZapIconPath({
@@ -309,8 +321,22 @@ function alertIcons(data: Datapoints, zoomOffset = 0): PlotAlert[] {
                       y: plot.y - 6,
                     })
                   "
+                  :fill="colors.red"
+                  :stroke="colors.bg"
+                />
+                <path
+                  v-show="plot.isAlertMixed"
+                  class="zap-icon"
+                  :d="
+                    getWarningIconPath({
+                      x: plot.x,
+                      y: plot.y - 18,
+                    })
+                  "
                   :fill="colors.amber"
                   :stroke="colors.bg"
+                  stroke-linecap="round"
+                  stroke-width="1.5"
                 />
               </template>
             </g>

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -44,6 +44,7 @@ const { data: hourlyWindow } = await useEcosystemHealthHourlyWindow()
           :scan-times="hourly.scanTimes"
           :counts-by-scan-time="hourly.countsByScanTime"
           :automation-threshold="25"
+          :mixed-threshold="25"
           hydrate-on-visible
         />
       </div>
@@ -52,6 +53,7 @@ const { data: hourlyWindow } = await useEcosystemHealthHourlyWindow()
           :scan-times="hourlyWindow.scanTimes"
           :counts-by-scan-time="hourlyWindow.countsByScanTime"
           :automation-threshold="50"
+          :mixed-threshold="50"
           hydrate-on-visible
         />
       </div>


### PR DESCRIPTION
Features:
- set zap icon color to red
- add warning icon for mixed series (same threshold as for automation)

<img width="774" height="479" alt="image" src="https://github.com/user-attachments/assets/691029c6-4574-4da8-892d-01ab52ad943e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Mixed-series threshold alerts to hourly event evolution charts.
  * Charts now display separate alert indicators: red lightning icons for Automation alerts and amber warning icons for Mixed alerts.
  * Configured thresholds for standard and windowed hourly charts to improve alert visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->