### PR TITLE
fix: make week chunks work with incomplete days

### DIFF
--- a/app/components/Report/WeeklyClassification.vue
+++ b/app/components/Report/WeeklyClassification.vue
@@ -110,7 +110,7 @@ const stackbarConfig = computed<VueUiStackbarConfig>(() => ({
       A new weekly data point is added after each Sunday scan
     </p>
   </div>
-  <div class="flex flex-col gap-4 weekly-classification">
+  <div class="flex flex-col gap-4 weekly-classification min-h-6">
     <ClientOnly>
       <VueUiStackbar :dataset="stackbarDataset" :config="stackbarConfig">
         <template #legend="{ legend }">

--- a/shared/utils/count-classification-by-date.ts
+++ b/shared/utils/count-classification-by-date.ts
@@ -592,6 +592,33 @@ function getCalendarWeekStartDates(dates: string[]): string[] {
   return [...new Set(dates.map((date) => getMondayDateKey(date)))].sort()
 }
 
+function getContinuousDateKeys(dates: string[]): string[] {
+  const dateKeys = [...new Set(dates.map((date) => getDateKey(date)))].sort()
+
+  const firstDate = dateKeys.at(0)
+  const lastDate = dateKeys.at(-1)
+
+  if (!firstDate || !lastDate) {
+    return []
+  }
+
+  const millisecondsPerDay = 24 * 60 * 60 * 1000
+  const firstTime = new Date(`${firstDate}T00:00:00.000Z`).getTime()
+
+  const lastTime = new Date(`${lastDate}T00:00:00.000Z`).getTime()
+
+  return Array.from(
+    {
+      length: Math.floor((lastTime - firstTime) / millisecondsPerDay) + 1,
+    },
+    (_, dayOffset) => {
+      return getDateKey(
+        new Date(firstTime + dayOffset * millisecondsPerDay).toISOString(),
+      )
+    },
+  )
+}
+
 function getClassificationByCalendarWeekChunks({
   data = [],
   dates = [],
@@ -599,19 +626,19 @@ function getClassificationByCalendarWeekChunks({
   data?: EcosystemHealthItem[]
   dates?: string[]
 }): ClassificationChunk[] {
-  const availableDateKeys = new Set(dates.map((date) => getDateKey(date)))
+  const continuousDates = getContinuousDateKeys(dates)
+  const firstDate = continuousDates.at(0)
+  const lastDate = continuousDates.at(-1)
 
-  return getCalendarWeekStartDates(dates)
+  if (!firstDate || !lastDate) {
+    return []
+  }
+
+  return getCalendarWeekStartDates(continuousDates)
     .map((startDate) => {
-      const weekDays = getNextDays({
-        date: startDate,
-        length: 7,
-      })
-
       const endDate = getSundayDateKey(startDate)
-      const isCompleteWeek = [...weekDays].every((date) => {
-        return availableDateKeys.has(date)
-      })
+
+      const isCompleteWeek = startDate >= firstDate && endDate <= lastDate
 
       if (!isCompleteWeek) {
         return null
@@ -649,10 +676,12 @@ export function getClassificationByDateChunks({
     })
   }
 
-  const sortedDates = [...dates].sort()
+  const sortedDates = getContinuousDateKeys(dates)
 
   return Array.from(
-    { length: Math.ceil(sortedDates.length / days) },
+    {
+      length: Math.ceil(sortedDates.length / days),
+    },
     (_, chunkIndex) => {
       const chunk = sortedDates.slice(
         chunkIndex * days,

--- a/test/unit/shared/utils/count-classification-by-date.test.ts
+++ b/test/unit/shared/utils/count-classification-by-date.test.ts
@@ -424,8 +424,8 @@ describe('getClassificationByDateChunks', () => {
 
     expect(result).toHaveLength(3)
 
-    expect(result[0].startDate).toBe('2026-06-01T10:00:00.000Z')
-    expect(result[0].endDate).toBe('2026-06-03T10:00:00.000Z')
+    expect(result[0].startDate).toBe('2026-06-01')
+    expect(result[0].endDate).toBe('2026-06-03')
     expect(result[0].days).toBe(3)
     expectClassificationCounts(result[0].classification, {
       organic: {
@@ -450,8 +450,8 @@ describe('getClassificationByDateChunks', () => {
       },
     })
 
-    expect(result[1].startDate).toBe('2026-06-04T10:00:00.000Z')
-    expect(result[1].endDate).toBe('2026-06-06T10:00:00.000Z')
+    expect(result[1].startDate).toBe('2026-06-04')
+    expect(result[1].endDate).toBe('2026-06-06')
     expect(result[1].days).toBe(3)
     expectClassificationCounts(result[1].classification, {
       organic: {
@@ -476,8 +476,8 @@ describe('getClassificationByDateChunks', () => {
       },
     })
 
-    expect(result[2].startDate).toBe('2026-06-07T10:00:00.000Z')
-    expect(result[2].endDate).toBe('2026-06-08T10:00:00.000Z')
+    expect(result[2].startDate).toBe('2026-06-07')
+    expect(result[2].endDate).toBe('2026-06-08')
     expect(result[2].days).toBe(2)
     expectClassificationCounts(result[2].classification, {
       organic: {
@@ -521,14 +521,61 @@ describe('getClassificationByDateChunks', () => {
     })
 
     expect(result.map((chunk) => chunk.startDate)).toEqual([
-      '2026-06-01T10:00:00.000Z',
-      '2026-06-03T10:00:00.000Z',
+      '2026-06-01',
+      '2026-06-03',
     ])
 
     expect(result.map((chunk) => chunk.endDate)).toEqual([
-      '2026-06-02T10:00:00.000Z',
-      '2026-06-04T10:00:00.000Z',
+      '2026-06-02',
+      '2026-06-04',
     ])
+  })
+
+  it('keeps calendar chunk boundaries stable when a day is missing', () => {
+    const result = getClassificationByDateChunks({
+      days: 3,
+      dates: [
+        '2026-06-01T10:00:00.000Z',
+        '2026-06-02T10:00:00.000Z',
+        '2026-06-03T10:00:00.000Z',
+        // June 4 is intentionally missing.
+        '2026-06-05T10:00:00.000Z',
+        '2026-06-06T10:00:00.000Z',
+      ],
+      data: [
+        createEcosystemHealthItem('2026-06-01T10:00:00.000Z', 90),
+        createEcosystemHealthItem('2026-06-02T10:00:00.000Z', 50),
+        createEcosystemHealthItem('2026-06-03T10:00:00.000Z', 10),
+        createEcosystemHealthItem('2026-06-05T10:00:00.000Z', 90),
+        createEcosystemHealthItem('2026-06-06T10:00:00.000Z', 10),
+      ],
+    })
+
+    expect(result).toHaveLength(2)
+
+    expect(
+      result.map(({ startDate, endDate, days }) => ({
+        startDate,
+        endDate,
+        days,
+      })),
+    ).toEqual([
+      {
+        startDate: '2026-06-01',
+        endDate: '2026-06-03',
+        days: 3,
+      },
+      {
+        startDate: '2026-06-04',
+        endDate: '2026-06-06',
+        days: 3,
+      },
+    ])
+
+    expect(result[1].classification.organic.count).toBe(1)
+    expect(result[1].classification.mixed.count).toBe(0)
+    expect(result[1].classification.automation.count).toBe(1)
+    expect(result[1].classification.total.count).toBe(2)
   })
 
   it('returns an empty array when dates are empty', () => {
@@ -549,6 +596,36 @@ describe('getClassificationByDateChunks', () => {
     })
 
     expect(result).toEqual([])
+  })
+
+  it('keeps a complete calendar week when one dataset day is missing', () => {
+    const result = getClassificationByDateChunks({
+      days: 7,
+      rolling: false,
+      dates: [
+        '2026-06-08T10:00:00.000Z',
+        '2026-06-09T10:00:00.000Z',
+        '2026-06-10T10:00:00.000Z',
+        // June 11 is intentionally missing.
+        '2026-06-12T10:00:00.000Z',
+        '2026-06-13T10:00:00.000Z',
+        '2026-06-14T10:00:00.000Z',
+      ],
+      data: [
+        createEcosystemHealthItem('2026-06-08T10:00:00.000Z', 90),
+        createEcosystemHealthItem('2026-06-09T10:00:00.000Z', 50),
+        createEcosystemHealthItem('2026-06-10T10:00:00.000Z', 10),
+        createEcosystemHealthItem('2026-06-12T10:00:00.000Z', 90),
+        createEcosystemHealthItem('2026-06-13T10:00:00.000Z', 50),
+        createEcosystemHealthItem('2026-06-14T10:00:00.000Z', 10),
+      ],
+    })
+
+    expect(result).toHaveLength(1)
+    expect(result[0].startDate).toBe('2026-06-08')
+    expect(result[0].endDate).toBe('2026-06-14')
+    expect(result[0].days).toBe(7)
+    expect(result[0].classification.total.count).toBe(6)
   })
 
   it('returns only complete Monday to Sunday calendar week chunks when rolling is false', () => {


### PR DESCRIPTION
The way we computed weekly chunks failed to create a new weekly entry for the bar chart in the lab.
The fix consists in filling missing calendar dates before chunking.

<img width="774" height="434" alt="image" src="https://github.com/user-attachments/assets/d4d0982f-c031-4898-841a-fb1b8ea873c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved weekly and date-based classification reporting when source data has missing days.
  - Date ranges now include empty calendar days, ensuring calendar weeks and fixed-length periods remain accurate and consistently aligned.
  - Corrected date range boundaries to display dates without unintended time information.
  - Added spacing to weekly classification results to improve visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->