### PR TITLE
refactor: improve health charts tooltips

### DIFF
--- a/app/components/Chart/EventsEvolutionTooltipTable.vue
+++ b/app/components/Chart/EventsEvolutionTooltipTable.vue
@@ -28,13 +28,17 @@ function getTrend({ item, index }: DatapointItem) {
 }
 
 function getProgressionVsPrevious({ item, index }: DatapointItem) {
-  const valueCurrent = (props.rawDataset[item.slotAbsoluteIndex]?.series[
-    index
-  ] ?? 0) as number
-  const valuePrevious = (props.rawDataset[item.slotAbsoluteIndex]?.series[
-    index - 1
-  ] ?? 0) as number
-  const delta = valueCurrent - valuePrevious
+  const valueCurrent = props.rawDataset[item.slotAbsoluteIndex]?.series[index]
+
+  const valuePrevious =
+    props.rawDataset[item.slotAbsoluteIndex]?.series[index - 1]
+
+  let delta = 0
+
+  if (typeof valueCurrent === 'number' && typeof valuePrevious === 'number') {
+    delta = valueCurrent - valuePrevious
+  }
+
   return {
     color: getTrendColor({ value: delta, reversed: item.name !== 'Organic' }),
     formattedValue: formatProgressionPoints(delta),

--- a/app/components/Chart/EventsEvolutionTooltipTable.vue
+++ b/app/components/Chart/EventsEvolutionTooltipTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { VueUiXyTooltipSlotProps } from 'vue-data-ui/vue-ui-xy'
+import type { VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
 import { formatProgressionPoints } from '~~/shared/utils/health-stats'
-import { type VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
 import { round } from '~~/shared/utils/numbers'
 
 const props = defineProps<{

--- a/app/components/Chart/EventsEvolutionTooltipTable.vue
+++ b/app/components/Chart/EventsEvolutionTooltipTable.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import type { VueUiXyTooltipSlotProps } from 'vue-data-ui/vue-ui-xy'
+import { formatProgressionPoints } from '~~/shared/utils/health-stats'
+import { type VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
+import { round } from '~~/shared/utils/numbers'
+
+const props = defineProps<{
+  tooltipSlotProps: Pick<
+    VueUiXyTooltipSlotProps,
+    'datapoint' | 'timeLabel' | 'series'
+  >
+  colors: Record<string, string>
+  canCompare?: boolean
+  rawDataset: VueUiXyDatasetItemWithTrends[]
+}>()
+
+type DatapointItem = {
+  item: { slotAbsoluteIndex: number; name: string }
+  index: number
+}
+
+function getTrend({ item, index }: DatapointItem) {
+  const trend = props.rawDataset[item.slotAbsoluteIndex]?.trends[index]
+  return {
+    formattedValue: formatTrend(trend),
+    color: getTrendColor({ value: trend, reversed: item.name !== 'Organic' }),
+  }
+}
+
+function getProgressionVsPrevious({ item, index }: DatapointItem) {
+  const valueCurrent = (props.rawDataset[item.slotAbsoluteIndex]?.series[
+    index
+  ] ?? 0) as number
+  const valuePrevious = (props.rawDataset[item.slotAbsoluteIndex]?.series[
+    index - 1
+  ] ?? 0) as number
+  const delta = valueCurrent - valuePrevious
+  return {
+    color: getTrendColor({ value: delta, reversed: item.name !== 'Organic' }),
+    formattedValue: formatProgressionPoints(delta),
+  }
+}
+</script>
+
+<template>
+  <table class="text-left">
+    <thead class="text-left text-xs">
+      <tr class="text-gh-muted">
+        <th class="px-2 text-right"></th>
+        <template v-if="canCompare">
+          <th class="px-2 text-right"></th>
+          <slot name="thead" />
+        </template>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr
+        v-for="dp in tooltipSlotProps.datapoint"
+        :key="`${dp.name}-${dp.absoluteIndex}`"
+      >
+        <td class="pr-2">
+          <div class="flex flex-row gap-2 place-items-center">
+            <div class="h-2 w-2">
+              <svg viewBox="0 0 2 2" class="h-full w-full">
+                <circle cx="1" cy="1" r="1" :fill="dp.color" />
+              </svg>
+            </div>
+
+            <span :style="{ color: colors.text }">
+              {{ dp.name }}
+            </span>
+          </div>
+        </td>
+
+        <td class="px-2 text-right">
+          <span :style="{ color: colors.text }">
+            {{ round(dp.value ?? 0, 1) + '%' }}
+          </span>
+        </td>
+
+        <template v-if="canCompare">
+          <td class="px-2 text-right border-l border-solid border-gh-border">
+            <template v-if="canCompare">
+              <span
+                :class="[
+                  getProgressionVsPrevious({
+                    item: dp,
+                    index: tooltipSlotProps.timeLabel.absoluteIndex,
+                  }).color,
+                ]"
+              >
+                {{
+                  getProgressionVsPrevious({
+                    item: dp,
+                    index: tooltipSlotProps.timeLabel.absoluteIndex,
+                  }).formattedValue
+                }}
+              </span>
+            </template>
+          </td>
+
+          <td class="px-2 text-left border-l border-solid border-gh-border">
+            <template v-if="tooltipSlotProps.timeLabel.absoluteIndex > 0">
+              <span
+                :class="[
+                  getTrend({
+                    item: dp,
+                    index: tooltipSlotProps.timeLabel.absoluteIndex,
+                  }).color,
+                ]"
+              >
+                {{
+                  getTrend({
+                    item: dp,
+                    index: tooltipSlotProps.timeLabel.absoluteIndex,
+                  }).formattedValue
+                }}
+              </span>
+            </template>
+          </td>
+        </template>
+      </tr>
+    </tbody>
+  </table>
+</template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -12,7 +12,7 @@ import { useColors } from '~/composables/useColors'
 import 'vue-data-ui/style.css'
 import { useIsMobile } from '~/composables/useIsMobile'
 import { landmarks, type Landmark } from './global-events-evolution-landmarks'
-import { type VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
+import type { VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
 import EventsEvolutionTooltipTable from './EventsEvolutionTooltipTable.vue'
 const { data: ecosystemHealth } = await useEcosystemHealth()
 
@@ -385,7 +385,7 @@ function placeLandmark({
                   :tooltip-slot-props="{ datapoint, timeLabel, series }"
                   :colors
                   :can-compare="timeLabel.absoluteIndex > 0"
-                  :rawDataset
+                  :raw-dataset="rawDataset"
                 >
                   <template #thead>
                     <th class="px-2 text-center">vs Day-1</th>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -8,11 +8,12 @@ import {
 } from 'vue-data-ui/vue-ui-xy'
 import { useTooltipPosition } from 'vue-data-ui/composables'
 import { useColors } from '~/composables/useColors'
-import { round } from '~~/shared/utils/numbers'
 
 import 'vue-data-ui/style.css'
 import { useIsMobile } from '~/composables/useIsMobile'
 import { landmarks, type Landmark } from './global-events-evolution-landmarks'
+import { type VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
+import EventsEvolutionTooltipTable from './EventsEvolutionTooltipTable.vue'
 const { data: ecosystemHealth } = await useEcosystemHealth()
 
 const chartContainer = useTemplateRef<HTMLElement>('chartContainer')
@@ -45,10 +46,6 @@ onMounted(() => {
 })
 
 const colors = useColors(rootEl)
-
-type VueUiXyDatasetItemWithTrends = VueUiXyDatasetItem & {
-  trends: number[]
-}
 
 function composeRawDataset(): VueUiXyDatasetItemWithTrends[] {
   return [
@@ -208,22 +205,6 @@ const config = computed<VueUiXyConfig>(() => ({
     zoom: { show: false },
   },
 }))
-
-function getTrend({
-  item,
-  index,
-}: {
-  item: { slotAbsoluteIndex: number; name: string }
-  index: number
-}) {
-  const trend = rawDataset.value[item.slotAbsoluteIndex]?.trends[index]
-
-  return {
-    formattedValue: formatTrend(trend),
-    color: getTrendColor({ value: trend, reversed: item.name !== 'Organic' }),
-    arrow: getTrendArrow(trend),
-  }
-}
 
 const keyDates = computed(() => {
   const dateList = dates.value ?? []
@@ -395,55 +376,22 @@ function placeLandmark({
             </template>
 
             <template #tooltip="{ datapoint, timeLabel, series }">
-              <div class="flex flex-col">
+              <div class="flex flex-col tabular-nums">
                 <div :style="{ color: colors.textMuted }" class="mb-1">
                   {{ timeLabel.text }}
                 </div>
-                <div
-                  v-for="dp in datapoint"
-                  :key="`${dp.name}-${dp.absoluteIndex}`"
-                  class="flex flex-row gap-2 place-items-center"
-                >
-                  <div class="h-2 w-2">
-                    <svg viewBox="0 0 2 2" class="w-full h-full">
-                      <circle cx="1" cy="1" r="1" :fill="dp.color" />
-                    </svg>
-                  </div>
-                  <span :style="{ color: colors.text }">{{ dp.name }}</span>
-                  <span :style="{ color: colors.textMuted }">
-                    {{ round(dp.value ?? 0, 1) + '%' }}
-                  </span>
 
-                  <!-- No trend is possible on the first datapoint -->
-                  <template v-if="timeLabel.absoluteIndex > 0">
-                    <span
-                      v-if="dp.slotAbsoluteIndex < series.length"
-                      :class="[
-                        getTrend({
-                          item: dp,
-                          index: timeLabel.absoluteIndex,
-                        }).color,
-                      ]"
-                    >
-                      <span
-                        :class="[
-                          getTrend({
-                            item: dp,
-                            index: timeLabel.absoluteIndex,
-                          }).arrow,
-                        ]"
-                        class="shrink-0"
-                        style="vertical-align: middle"
-                      />
-                      {{
-                        getTrend({
-                          item: dp,
-                          index: timeLabel.absoluteIndex,
-                        }).formattedValue
-                      }}
-                    </span>
+                <EventsEvolutionTooltipTable
+                  :tooltip-slot-props="{ datapoint, timeLabel, series }"
+                  :colors
+                  :can-compare="timeLabel.absoluteIndex > 0"
+                  :rawDataset
+                >
+                  <template #thead>
+                    <th class="px-2 text-center">vs Day-1</th>
+                    <th class="px-2 text-left">Trend</th>
                   </template>
-                </div>
+                </EventsEvolutionTooltipTable>
 
                 <!-- LANDMARK INFO -->
                 <div
@@ -455,7 +403,7 @@ function placeLandmark({
                       timeLabel.absoluteIndex,
                     ) ?? []"
                     :key="`${landmark.date}-${landmark.name}-${landmark.series ?? 'global'}`"
-                    class="flex flex-row gap-2 max-w-[240px]"
+                    class="flex flex-row gap-2 max-w-[280px]"
                   >
                     <span class="w-6 shrink-0" :class="landmark.icon" />
 
@@ -495,5 +443,9 @@ function placeLandmark({
 
 .landmark-label {
   transition: all 250ms ease !important;
+}
+
+.vue-data-ui-tooltip {
+  min-width: fit-content !important;
 }
 </style>

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -9,6 +9,7 @@ import { useElementSize } from '@vueuse/core'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { round } from '~~/shared/utils/numbers'
+import EventsEvolutionTooltipTable from './EventsEvolutionTooltipTable.vue'
 
 dayjs.extend(utc)
 
@@ -283,68 +284,23 @@ const isChartHovered = shallowRef(false)
               </linearGradient>
             </template>
 
-            <template #tooltip="{ datapoint, timeLabel }">
+            <template #tooltip="{ datapoint, timeLabel, series }">
               <div class="flex flex-col">
                 <div :style="{ color: colors.textMuted }" class="mb-1">
                   {{ formatScanTime(timeLabel.absoluteIndex) }}
                 </div>
-                <div
-                  v-for="dp in datapoint"
-                  :key="`${dp.name}-${dp.absoluteIndex}`"
-                  class="flex flex-row gap-2 place-items-center"
-                >
-                  <div class="h-2 w-2 shrink-0">
-                    <svg viewBox="0 0 2 2" class="w-full h-full">
-                      <circle cx="1" cy="1" r="1" :fill="dp.color" />
-                    </svg>
-                  </div>
-                  <span :style="{ color: colors.text }">{{ dp.name }}</span>
-                  <span
-                    :style="{ color: colors.textMuted }"
-                    class="tabular-nums"
-                  >
-                    {{ round(dp.value ?? 0, 1) + '%' }}
-                  </span>
-                  <span
-                    :style="{ color: colors.textMuted }"
-                    class="tabular-nums"
-                  >
-                    {{
-                      getScanDetails({
-                        serieIndex: dp.slotAbsoluteIndex,
-                        index: timeLabel.absoluteIndex,
-                      })
-                    }}
-                  </span>
 
-                  <!-- No trend is possible on the first datapoint -->
-                  <span
-                    v-if="timeLabel.absoluteIndex > 0"
-                    :class="[
-                      getTrend({
-                        serieIndex: dp.slotAbsoluteIndex,
-                        index: timeLabel.absoluteIndex,
-                      }).color,
-                    ]"
-                  >
-                    <span
-                      :class="[
-                        getTrend({
-                          serieIndex: dp.slotAbsoluteIndex,
-                          index: timeLabel.absoluteIndex,
-                        }).arrow,
-                      ]"
-                      class="shrink-0"
-                      style="vertical-align: middle"
-                    />
-                    {{
-                      getTrend({
-                        serieIndex: dp.slotAbsoluteIndex,
-                        index: timeLabel.absoluteIndex,
-                      }).formattedValue
-                    }}
-                  </span>
-                </div>
+                <EventsEvolutionTooltipTable
+                  :tooltip-slot-props="{ datapoint, timeLabel, series }"
+                  :colors
+                  :can-compare="timeLabel.absoluteIndex > 0"
+                  :rawDataset
+                >
+                  <template #thead>
+                    <th class="px-2 text-center">vs Hour-1</th>
+                    <th class="px-2 text-left">Trend</th>
+                  </template>
+                </EventsEvolutionTooltipTable>
               </div>
             </template>
 

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -192,23 +192,6 @@ const config = computed<VueUiXyConfig>(() => ({
   },
 }))
 
-function getTrend({
-  serieIndex,
-  index,
-}: {
-  serieIndex: number
-  index: number
-}) {
-  const serie = rawDataset.value[serieIndex]
-  const trend = serie?.trends[index]
-
-  return {
-    formattedValue: formatTrend(trend),
-    color: getTrendColor({ value: trend, reversed: serie?.name !== 'Organic' }),
-    arrow: getTrendArrow(trend),
-  }
-}
-
 function formatScanTime(index: number) {
   const scanTime = scanTimes.value?.[index]
 
@@ -217,24 +200,6 @@ function formatScanTime(index: number) {
   }
 
   return dayjs(scanTime).format('ddd, MMM D • HH:mm')
-}
-
-function getScanDetails({
-  serieIndex,
-  index,
-}: {
-  serieIndex: number
-  index: number
-}) {
-  const serie = rawDataset.value[serieIndex]
-  const count = serie?.counts[index]
-  const total = serie?.totals[index]
-
-  if (count === undefined || !total) {
-    return ''
-  }
-
-  return `${count} / ${total}`
 }
 
 const progressionLabelOffsetX = 0
@@ -294,7 +259,7 @@ const isChartHovered = shallowRef(false)
                   :tooltip-slot-props="{ datapoint, timeLabel, series }"
                   :colors
                   :can-compare="timeLabel.absoluteIndex > 0"
-                  :rawDataset
+                  :raw-dataset="rawDataset"
                 >
                   <template #thead>
                     <th class="px-2 text-center">vs Hour-1</th>

--- a/shared/types/ecosystem-health.ts
+++ b/shared/types/ecosystem-health.ts
@@ -1,3 +1,4 @@
+import type { VueUiXyDatasetItem } from 'vue-data-ui/vue-ui-xy'
 import type { calcLinearProgression } from '../utils/calc-linear-progression'
 import type { IdentityClassification } from '@unveil/identity'
 
@@ -32,3 +33,7 @@ export type EcosystemHealthCategoryProgression = Record<
   EcosystemHealthCategory,
   ReturnType<typeof calcLinearProgression>
 >
+
+export type VueUiXyDatasetItemWithTrends = VueUiXyDatasetItem & {
+  trends: number[]
+}

--- a/shared/utils/health-stats.ts
+++ b/shared/utils/health-stats.ts
@@ -31,6 +31,13 @@ export function formatTrend(value: number = 0) {
   return `${round(value * 100, 1)}%`
 }
 
+export function formatProgressionPoints(value: number) {
+  const rounded = round(value, 1)
+  const sign = value > 0 ? '+' : ''
+  const unit = Math.abs(rounded) === 1 ? 'pt' : 'pts'
+  return `${sign}${rounded}${unit}`
+}
+
 export function getHealthStats(
   data: EcosystemHealthItem[] = [],
 ): Record<

--- a/test/unit/shared/utils/health-stats.test.ts
+++ b/test/unit/shared/utils/health-stats.test.ts
@@ -4,6 +4,7 @@ import {
   classifyByScore,
   formatTrend,
   getHealthStats,
+  formatProgressionPoints,
   INSUFFICIENT_DATA_SCORE,
 } from '../../../../shared/utils/health-stats'
 import { MOCK_ECOSYSTEM_HEALTH_ITEMS } from '../../mocks/ecosystemHealthItems'
@@ -69,5 +70,17 @@ describe('getHealthStats', () => {
     ] as EcosystemHealthItem[]
 
     expect(getHealthStats(items)).toBeNull()
+  })
+})
+
+describe('formatProgressionPoints', () => {
+  it('formats a value into a signed string with a suffix', () => {
+    expect(formatProgressionPoints(0)).toBe('0pts')
+    expect(formatProgressionPoints(-1)).toBe('-1pt')
+    expect(formatProgressionPoints(1)).toBe('+1pt')
+    expect(formatProgressionPoints(-1.49)).toBe('-1.5pts')
+    expect(formatProgressionPoints(1.49)).toBe('+1.5pts')
+    expect(formatProgressionPoints(1.99)).toBe('+2pts')
+    expect(formatProgressionPoints(-1.99)).toBe('-2pts')
   })
 })


### PR DESCRIPTION
This improves the layout of the health charts tooltips:

- add day-1 & hour-1 compares
- display data into a table

| Daily | Hourly |
| - | - |
|<img width="352" alt="image" src="https://github.com/user-attachments/assets/db3a55c6-ce73-430d-bb8e-9f9b3360e47d" />|<img width="352" alt="image" src="https://github.com/user-attachments/assets/fe036590-9d5c-419f-977c-ef6d6e9ed500" />|

The table part was abstracted into a component to keep things dry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event evolution chart tooltips with datapoint values, progression versus previous points, and trend indicators.
  * Added clearer visual cues for positive and negative movements, including series-specific interpretation.
  * Improved tooltip layouts for landmark and hourly event views.
  * Added consistent formatting for progression points, including signs and singular/plural labels.

* **Tests**
  * Added coverage for progression-point formatting, rounding, signs, and zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->