### PR TITLE
fix: remove bottom padding for hourly chart on mobile

### DIFF
--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -130,7 +130,10 @@ const config = computed<VueUiXyConfig>(() => ({
     padding: {
       left: viewBoxPadding.value.left,
       right: viewBoxPadding.value.right,
-      bottom: 36,
+      /**
+       * Extra padding bottom is added on desktop to compensate the illusion of height difference between the daily and hourly charts, and avoid a CLS impression when switching between them; but not on mobile, where we need all the real estate we can use.
+       */
+      bottom: isMobile.value ? 0 : 36,
     },
     highlighter: {
       opacity: 1,


### PR DESCRIPTION
This sets bottom padding to 0 on mobile for the hourly health chart.

Extra padding bottom is added on desktop to compensate the illusion of height difference between the daily and hourly charts, and avoid a CLS impression when switching between them; but not on mobile, where we need all the real estate we can use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chart spacing responsiveness: desktop views retain bottom padding, while mobile views use the available space more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->