### PR TITLE
feat(lab): add radar chart

### DIFF
--- a/app/components/Chart/AccountEventsRadar.vue
+++ b/app/components/Chart/AccountEventsRadar.vue
@@ -1,0 +1,194 @@
+<script setup lang="ts">
+import { usePreferredDark } from '@vueuse/core'
+import { ref, computed } from 'vue'
+import { VueUiRadar, type VueUiRadarDataset } from 'vue-data-ui/vue-ui-radar'
+
+// TODO: props, when the component is plugged to the main search
+// props: username, flags should be enough
+
+import('vue-data-ui/style.css')
+
+const rootEl = shallowRef<HTMLElement | null>(null)
+
+onMounted(() => {
+  rootEl.value = document.documentElement
+})
+
+const colors = useColors(rootEl)
+const darkMode = usePreferredDark()
+
+// TODO: abstract outside of the component
+const GROUPS = {
+  ['pr-outcome']: { max: 80, name: 'PR outcome', description: '' },
+  fork: {
+    max: 100,
+    name: 'Fork',
+    description: 'Lorem ipsum dolor sit amet consectetur what the fork',
+  },
+  ['pr-volume']: { max: 75, name: 'PR volume', description: '' },
+  ['branch-pr']: { max: 49, name: 'Branch PR', description: '' },
+  ['external-focus']: { max: 60, name: 'External focus', description: '' },
+  ['repo-creation']: { max: 35, name: 'Repo creation', description: '' },
+  watch: { max: 35, name: 'Watch', description: '' },
+  ['comment-pr-timing']: {
+    max: 30,
+    name: 'Comment PR timing',
+    description: '',
+  },
+  timing: { max: 56, name: 'Timing', description: '' },
+  diversity: { max: 20, name: 'Diversity', description: '' },
+  engagement: { max: 25, name: 'Engagement', description: '' },
+  ['repo-spread']: { max: 30, name: 'Repo spread', description: '' },
+  ['comment-volume']: { max: 40, name: 'Comment vol.', description: '' },
+  ['pr-comment-volume']: { max: 38, name: 'PR comment vol.', description: '' },
+  ['account-age']: { max: 30, name: 'Account age', description: '' },
+  bounty: { max: 25, name: 'Bounty', description: '' },
+}
+
+const accountName = ref('')
+const username = ref('')
+const flags = ref<Flag[]>([])
+const classification = ref('')
+
+type Flag = {
+  group: string
+  points: number
+  label: string
+  detail: string
+}
+
+// TODO: to be removed when the component is plugged to the main search
+async function handleSubmit(name: string) {
+  const user = await $fetch(`/api/account/${name}`)
+  username.value = user?.login ?? ''
+  if (!username.value) {
+    flags.value = []
+    return
+  }
+  const userData = await $fetch(`/api/identify-replicant/${username.value}`, {
+    query: {
+      show_events: true,
+    },
+  })
+  classification.value = userData?.analysis?.classification ?? ''
+  flags.value = userData?.analysis?.flags ?? []
+}
+
+const userColor = computed(
+  () =>
+    colors.value[classification.value as keyof typeof colors.value] ??
+    colors.value.border,
+)
+
+function createRadarDataset(
+  username: string,
+  flags: Flag[],
+): VueUiRadarDataset {
+  return {
+    categories: [
+      {
+        name: username,
+        color: userColor.value,
+      },
+    ],
+    series: Object.entries(GROUPS)
+      .map(([group, { max, name }]) => {
+        const flag = flags.find((flag) => flag.group === group)
+
+        return {
+          name,
+          values: [flag?.points ?? 0],
+          target: max,
+          description: flag?.label,
+          detail: flag?.detail,
+        }
+      })
+      .sort(
+        (a, b) =>
+          (b.values?.[0] ?? 0) / b.target - (a.values?.[0] ?? 0) / a.target,
+      ),
+  }
+}
+
+const dataset = computed(() => createRadarDataset(username.value, flags.value))
+
+const config = computed(() => ({
+  userOptions: { show: false },
+  style: {
+    chart: {
+      backgroundColor: colors.value.bg,
+      layout: {
+        scaleToAxisMax: true, // avoid overflow if points > max
+        grid: {
+          rotation: -90,
+          stroke: colors.value.border,
+          strokeWidth: 0.3,
+          graduations: 3,
+        },
+        labels: {
+          dataLabels: {
+            fontSize: 10,
+            color: darkMode.value
+              ? colors.value.textFaint
+              : colors.value.textMuted,
+            offset: 0,
+          },
+        },
+        dataPolygon: {
+          useGradient: false,
+        },
+        outerPolygon: {
+          stroke: colors.value.border,
+          strokeWidth: 0.3,
+        },
+      },
+      legend: {
+        show: false,
+      },
+      tooltip: {
+        backgroundColor: colors.value.bg,
+        color: colors.value.text,
+        borderColor: colors.value.border,
+        backgroundOpacity: 70,
+      },
+    },
+  },
+}))
+</script>
+
+<template>
+  <div class="max-w-2xl mx-auto">
+    <!-- TODO: to be removed when the component is plugged to the main search -->
+    <AnalysisForm v-model="accountName" autofocus @submit="handleSubmit" />
+  </div>
+
+  <div>
+    <ClientOnly>
+      <VueUiRadar :dataset="dataset" :config>
+        <template #tooltip="{ datapoint }">
+          <div class="text-center tabular-nums">
+            <div>{{ datapoint.name }}</div>
+            <div class="text-[--text-muted] text-xs max-w-[200px] my-2">
+              {{ datapoint.description }}
+            </div>
+            <div class="flex flex-row items-baseline gap-1 justify-center">
+              <span :style="{ color: userColor }" class="text-2xl">
+                {{ datapoint.values[0] }}
+              </span>
+              <span class="text-[--text-muted]">/</span>
+              <span class="text-[--text-muted]">
+                {{ datapoint.target }}
+              </span>
+            </div>
+            <div
+              v-if="datapoint.detail"
+              class="text-[--text-muted] text-xs max-w-[200px] text-left py-2 mt-2 border-t border-[--text-faint]"
+            >
+              {{ datapoint.detail }}
+            </div>
+          </div>
+        </template>
+      </VueUiRadar>
+    </ClientOnly>
+  </div>
+</template>

--- a/app/components/Chart/AccountEventsRadar.vue
+++ b/app/components/Chart/AccountEventsRadar.vue
@@ -4,7 +4,7 @@ import { ref, computed } from 'vue'
 import { VueUiRadar, type VueUiRadarDataset } from 'vue-data-ui/vue-ui-radar'
 
 // TODO: props, when the component is plugged to the main search
-// props: username, flags should be enough
+// props: username, flags & classification should be enough
 
 import('vue-data-ui/style.css')
 

--- a/app/components/Chart/AccountEventsRadar.vue
+++ b/app/components/Chart/AccountEventsRadar.vue
@@ -19,30 +19,28 @@ const darkMode = usePreferredDark()
 
 // TODO: abstract outside of the component
 const GROUPS = {
-  ['pr-outcome']: { max: 80, name: 'PR outcome', description: '' },
+  ['pr-outcome']: { max: 80, name: 'PR outcome' },
   fork: {
     max: 100,
     name: 'Fork',
-    description: 'Lorem ipsum dolor sit amet consectetur what the fork',
   },
-  ['pr-volume']: { max: 75, name: 'PR volume', description: '' },
-  ['branch-pr']: { max: 49, name: 'Branch PR', description: '' },
-  ['external-focus']: { max: 60, name: 'External focus', description: '' },
-  ['repo-creation']: { max: 35, name: 'Repo creation', description: '' },
-  watch: { max: 35, name: 'Watch', description: '' },
+  ['pr-volume']: { max: 75, name: 'PR volume' },
+  ['branch-pr']: { max: 49, name: 'Branch PR' },
+  ['external-focus']: { max: 60, name: 'External focus' },
+  ['repo-creation']: { max: 35, name: 'Repo creation' },
+  watch: { max: 35, name: 'Watch' },
   ['comment-pr-timing']: {
     max: 30,
     name: 'Comment PR timing',
-    description: '',
   },
-  timing: { max: 56, name: 'Timing', description: '' },
-  diversity: { max: 20, name: 'Diversity', description: '' },
-  engagement: { max: 25, name: 'Engagement', description: '' },
-  ['repo-spread']: { max: 30, name: 'Repo spread', description: '' },
-  ['comment-volume']: { max: 40, name: 'Comment vol.', description: '' },
-  ['pr-comment-volume']: { max: 38, name: 'PR comment vol.', description: '' },
-  ['account-age']: { max: 30, name: 'Account age', description: '' },
-  bounty: { max: 25, name: 'Bounty', description: '' },
+  timing: { max: 56, name: 'Timing' },
+  diversity: { max: 20, name: 'Diversity' },
+  engagement: { max: 25, name: 'Engagement' },
+  ['repo-spread']: { max: 30, name: 'Repo spread' },
+  ['comment-volume']: { max: 40, name: 'Comment vol.' },
+  ['pr-comment-volume']: { max: 38, name: 'PR comment vol.' },
+  ['account-age']: { max: 30, name: 'Account age' },
+  bounty: { max: 25, name: 'Bounty' },
 }
 
 const accountName = ref('')

--- a/app/composables/useColors.ts
+++ b/app/composables/useColors.ts
@@ -19,14 +19,28 @@ type UseCssVariableOptions = {
   element?: CssVariableSource
 }
 
+type CamelCase<S extends string> = S extends `${infer Head}-${infer Tail}`
+  ? `${Head}${Capitalize<CamelCase<Tail>>}`
+  : S
+
+type CssVariableKey<S extends string> = S extends `--${infer Name}`
+  ? CamelCase<Name>
+  : CamelCase<S>
+
+type CssVariables<T extends readonly string[]> = {
+  [K in T[number] as CssVariableKey<K>]: string
+}
+
 function readCssVariable(element: HTMLElement, variableName: string): string {
   return getComputedStyle(element).getPropertyValue(variableName).trim()
 }
 
-function toCamelCase(cssVariable: string): string {
+function toCamelCase<T extends string>(cssVariable: T): CssVariableKey<T> {
   return cssVariable
     .replace(/^--/, '')
-    .replace(/-([a-z0-9])/gi, (_, c) => c.toUpperCase())
+    .replace(/-([a-z0-9])/gi, (_, c: string) =>
+      c.toUpperCase(),
+    ) as CssVariableKey<T>
 }
 
 function resolveElement(element?: CssVariableSource): HTMLElement | null {
@@ -43,10 +57,10 @@ function resolveElement(element?: CssVariableSource): HTMLElement | null {
   return resolved ?? document.documentElement
 }
 
-export function useCssVariables(
-  variables: readonly string[],
+export function useCssVariables<const T extends readonly string[]>(
+  variables: T,
   options: UseCssVariableOptions = {},
-): { colors: ComputedRef<Record<string, string>> } {
+): { colors: ComputedRef<CssVariables<T>> } {
   const recomputeToken = shallowRef(0)
   const isPreferredDark = usePreferredDark()
 
@@ -58,12 +72,12 @@ export function useCssVariables(
 
   const elementComputed = computed(() => resolveElement(options.element))
 
-  const colors = computed<Record<string, string>>(() => {
+  const colors = computed<CssVariables<T>>(() => {
     void recomputeToken.value
 
     const element = elementComputed.value
     if (!element) {
-      return {}
+      return {} as CssVariables<T>
     }
 
     const result: Record<string, string> = {}
@@ -72,7 +86,7 @@ export function useCssVariables(
       result[toCamelCase(variable)] = readCssVariable(element, variable)
     }
 
-    return result
+    return result as CssVariables<T>
   })
 
   return { colors }

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -50,6 +50,15 @@ const { data: hourly } = await useEcosystemHealthHourly()
       <div class="w-full">
         <LazyChartGlobalEventsHeatmap />
       </div>
+      <div class="w-full">
+        <div class="mb-6">
+          <h2 class="text-center">Experimental account scan mapping</h2>
+          <p class="text-sm text-ui-muted text-center">
+            Search for a user to view all flags graphed in a radar chart.
+          </p>
+        </div>
+        <LazyChartAccountEventsRadar />
+      </div>
     </div>
   </section>
 </template>

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.2.0",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.23.0",
+    "vue-data-ui": "^3.23.5",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.23.0
-        version: 3.23.0(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.23.5
+        version: 3.23.5(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -6084,8 +6084,8 @@ packages:
   vue-bundle-renderer@2.3.1:
     resolution: {integrity: sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==}
 
-  vue-data-ui@3.23.0:
-    resolution: {integrity: sha512-Drgg76fb+eOn5yLFsUX7Kvfs3Fcyfpv0QKXL8EVfprklTeyWseeqeiP2yJWWSFD79JfB/4Ap6Dwtp2/w1RiwMw==}
+  vue-data-ui@3.23.5:
+    resolution: {integrity: sha512-f0GUjRatJQ305e7OPOW3htV9jEsSzqJ2zGJSQoq0yEAXuQmxF08DsERd5MsdUG2f1tH0YKbRaD/QuXklts2NrA==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -12868,7 +12868,7 @@ snapshots:
     dependencies:
       ufo: 1.6.4
 
-  vue-data-ui@3.23.0(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.23.5(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 


### PR DESCRIPTION
This adds an experimental user scan flag mapping on a radar chart in the lab.

<img width="700" height="594" alt="image" src="https://github.com/user-attachments/assets/68cf2fe7-850a-4e8e-90f7-24428d451a3f" />

Note: there is no error handling as it will be handled by the main search eventually

Other:

- bump vue-data-ui to latest
- autocomplete for colors from useColors composable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental account scan visualization to the Lab page.
  * Introduced an interactive radar chart showing account analysis scores, targets, categories, and detailed tooltips.
  * Added account search support for exploring scan results.
  * Chart appearance adapts to light and dark themes.

* **Improvements**
  * Enhanced color handling for more consistent visual styling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->