### PR TITLE
feat: add hourly legend stats

### DIFF
--- a/app/components/Health/TrendItemList.vue
+++ b/app/components/Health/TrendItemList.vue
@@ -1,20 +1,36 @@
 <script setup lang="ts">
 import type { EcosystemHealthCategory } from '~~/shared/types/ecosystem-health'
 
+const props = withDefaults(
+  defineProps<{
+    view?: string
+  }>(),
+  {
+    view: 'daily',
+  },
+)
+
 type ClassificationStats = Record<
   EcosystemHealthCategory,
   { count: number; percentage: string }
 >
 
-const { data: ecosystemHealth } = await useEcosystemHealth()
-const entries = computed(() => ecosystemHealth.value?.entries ?? [])
+const { data: ecosystemHealthDaily } = await useEcosystemHealth()
+const { data: ecosystemHealthHourly } = await useEcosystemHealthHourlyWindow()
+
+const entriesDaily = computed(() => ecosystemHealthDaily.value?.entries ?? [])
+const entriesHourly = computed(() => ecosystemHealthHourly.value?.entries ?? [])
 
 const categoryProgression = computed(() => {
-  return ecosystemHealth.value?.categoryProgression
+  return props.view === 'daily'
+    ? ecosystemHealthDaily.value?.categoryProgression
+    : ecosystemHealthHourly.value?.categoryProgression
 })
 
 const latestDayStats = computed<ClassificationStats | null>(() => {
-  return getDailyHealthStats(entries.value)
+  return props.view === 'daily'
+    ? getHealthStatsFromEntries(entriesDaily.value)
+    : getHealthStatsFromEntries(entriesHourly.value)
 })
 </script>
 

--- a/app/components/Health/TrendItemListDaily.vue
+++ b/app/components/Health/TrendItemListDaily.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { EcosystemHealthCategory } from '~~/shared/types/ecosystem-health'
+
+type ClassificationStats = Record<
+  EcosystemHealthCategory,
+  { count: number; percentage: string }
+>
+
+const { data: ecosystemHealth } = await useEcosystemHealth()
+const entries = computed(() => ecosystemHealth.value?.entries ?? [])
+
+const categoryProgression = computed(() => {
+  return ecosystemHealth.value?.categoryProgression
+})
+
+const latestDayStats = computed<ClassificationStats | null>(() => {
+  return getHealthStatsFromEntries(entries.value)
+})
+</script>
+
+<template>
+  <ul
+    class="text-center flex flex-col md:flex-row gap-2 items-center md:text-left w-full justify-evenly"
+  >
+    <li>
+      <HealthTrend
+        classification="organic"
+        label="Organic"
+        :trend="categoryProgression?.organic.trend"
+        :percentage="latestDayStats?.organic.percentage"
+      />
+    </li>
+    <li>
+      <HealthTrend
+        classification="mixed"
+        label="Mixed"
+        :trend="categoryProgression?.mixed.trend"
+        :percentage="latestDayStats?.mixed.percentage"
+      />
+    </li>
+    <li>
+      <HealthTrend
+        classification="automation"
+        label="Automation"
+        :trend="categoryProgression?.automation.trend"
+        :percentage="latestDayStats?.automation.percentage"
+      />
+    </li>
+  </ul>
+</template>

--- a/app/components/Health/TrendItemListHourly.vue
+++ b/app/components/Health/TrendItemListHourly.vue
@@ -1,36 +1,20 @@
 <script setup lang="ts">
 import type { EcosystemHealthCategory } from '~~/shared/types/ecosystem-health'
 
-const props = withDefaults(
-  defineProps<{
-    view?: string
-  }>(),
-  {
-    view: 'daily',
-  },
-)
-
 type ClassificationStats = Record<
   EcosystemHealthCategory,
   { count: number; percentage: string }
 >
-
-const { data: ecosystemHealthDaily } = await useEcosystemHealth()
 const { data: ecosystemHealthHourly } = await useEcosystemHealthHourlyWindow()
 
-const entriesDaily = computed(() => ecosystemHealthDaily.value?.entries ?? [])
 const entriesHourly = computed(() => ecosystemHealthHourly.value?.entries ?? [])
 
 const categoryProgression = computed(() => {
-  return props.view === 'daily'
-    ? ecosystemHealthDaily.value?.categoryProgression
-    : ecosystemHealthHourly.value?.categoryProgression
+  return ecosystemHealthHourly.value?.categoryProgression
 })
 
 const latestDayStats = computed<ClassificationStats | null>(() => {
-  return props.view === 'daily'
-    ? getHealthStatsFromEntries(entriesDaily.value)
-    : getHealthStatsFromEntries(entriesHourly.value)
+  return getHealthStatsFromEntries(entriesHourly.value)
 })
 </script>
 

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -86,8 +86,11 @@ const urlParams = useUrlSearchParams<{ view: ChartRange | undefined }>(
               </p>
             </header>
 
-            <div class="mt-4 px-4 md:py-4 md:border-y md:border-y-ui-border/40">
-              <HealthTrendItemList :view="urlParams.view" />
+            <div
+              class="mt-4 px-4 md:py-4 md:border-y md:border-y-ui-border/40 min-h-[54px]"
+            >
+              <HealthTrendItemListDaily v-if="urlParams.view === 'daily'" />
+              <HealthTrendItemListHourly v-else />
             </div>
 
             <div class="mt-6 mb-3 flex flex-col items-center gap-1.5 px-4">

--- a/app/pages/health.vue
+++ b/app/pages/health.vue
@@ -87,7 +87,7 @@ const urlParams = useUrlSearchParams<{ view: ChartRange | undefined }>(
             </header>
 
             <div class="mt-4 px-4 md:py-4 md:border-y md:border-y-ui-border/40">
-              <HealthTrendItemList />
+              <HealthTrendItemList :view="urlParams.view" />
             </div>
 
             <div class="mt-6 mb-3 flex flex-col items-center gap-1.5 px-4">

--- a/server/api/health/hourly-window.get.ts
+++ b/server/api/health/hourly-window.get.ts
@@ -1,10 +1,15 @@
 import { unpack } from '~~/shared/utils/compactor'
+import type { ScanEntry } from '~~/shared/utils/daily-rollup'
 import {
   applyCumulativeTrends,
   fillEmptyHourlyBuckets,
   getClassificationStatsByScanTime,
 } from '~~/shared/utils/count-classification-by-date'
 import { WINDOW_MAX_HOURS } from '~~/shared/utils/health-history-window'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
 
 export default defineEventHandler(async () => {
   try {
@@ -32,7 +37,18 @@ export default defineEventHandler(async () => {
     const categoryProgression = applyCumulativeTrends(countsByScanTime)
     const scanTimes = Object.keys(countsByScanTime).sort()
 
+    const entries = Object.values(countsByScanTime).map((entry) => ({
+      date: dayjs(entry.createdAt).format('YYYY-MM-DD'),
+      createdAt: entry.createdAt,
+      classifications: {
+        organic: { count: entry.organic.count },
+        mixed: { count: entry.mixed.count },
+        automation: { count: entry.automation.count },
+      },
+    })) as ScanEntry[]
+
     return {
+      entries,
       results,
       categoryProgression,
       countsByScanTime,

--- a/server/api/health/hourly-window.get.ts
+++ b/server/api/health/hourly-window.get.ts
@@ -38,7 +38,7 @@ export default defineEventHandler(async () => {
     const scanTimes = Object.keys(countsByScanTime).sort()
 
     const entries = Object.values(countsByScanTime).map((entry) => ({
-      date: dayjs(entry.createdAt).format('YYYY-MM-DD'),
+      date: dayjs.utc(entry.createdAt).format('YYYY-MM-DD'),
       createdAt: entry.createdAt,
       classifications: {
         organic: { count: entry.organic.count },

--- a/shared/utils/daily-rollup.ts
+++ b/shared/utils/daily-rollup.ts
@@ -25,6 +25,8 @@ export type DailyScanEntry = {
   classifications: Record<IdentityClassification, DailyClassificationCounts>
 }
 
+export type ScanEntry = Omit<DailyScanEntry, 'hours'>
+
 type DailyScanBucket = Omit<DailyScanEntry, 'date' | 'hours'> & {
   hours: Set<string>
 }
@@ -168,8 +170,8 @@ export function getDailyCountsByDate(
   return result
 }
 
-export function getDailyHealthStats(
-  entries: DailyScanEntry[],
+export function getHealthStatsFromEntries(
+  entries: ScanEntry[],
 ): Record<
   EcosystemHealthCategory,
   { count: number; percentage: string }


### PR DESCRIPTION
Resolves #333

Add entries in the hourly window endpoint, and condition the legend component to the selected view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hourly health trend support alongside the existing daily view.
  * Health trend data now updates based on the selected chart view.
  * Hourly results include timestamps and classification counts for clearer trend analysis.
  * Daily view remains the default experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->