### PR TITLE
refactor: health tooltip header with pr counts

### DIFF
--- a/app/components/Chart/EventsEvolutionTooltipHeader.vue
+++ b/app/components/Chart/EventsEvolutionTooltipHeader.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    timeLabel: string
+    count: number
+    countLabel?: string
+  }>(),
+  {
+    countLabel: 'Pull requests scanned:',
+  },
+)
+</script>
+
+<template>
+  <div class="mb-1 flex flex-col text-[--text-muted]">
+    <span>{{ timeLabel }}</span>
+    <span>{{ countLabel }} {{ count }}</span>
+  </div>
+</template>

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -358,7 +358,7 @@ function placeLandmark({
             >
               <div class="flex flex-col tabular-nums">
                 <ChartEventsEvolutionTooltipHeader
-                  :timeLabel="timeLabel.text"
+                  :time-label="timeLabel.text"
                   :count="
                     getTotalPrScanned(
                       series as VueUiXySeriesWithCounts,

--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -12,8 +12,15 @@ import { useColors } from '~/composables/useColors'
 import 'vue-data-ui/style.css'
 import { useIsMobile } from '~/composables/useIsMobile'
 import { landmarks, type Landmark } from './global-events-evolution-landmarks'
-import type { VueUiXyDatasetItemWithTrends } from '~~/shared/types/ecosystem-health'
-import EventsEvolutionTooltipTable from './EventsEvolutionTooltipTable.vue'
+import type {
+  EventsEvolutionSeries,
+  VueUiXySeriesWithCounts,
+} from '~~/shared/types/ecosystem-health'
+import {
+  CLASSIFICATIONS_WITH_NAME_AND_CATEGORY,
+  getTotalPrScanned,
+} from '~~/shared/utils/charts.ts'
+
 const { data: ecosystemHealth } = await useEcosystemHealth()
 
 const chartContainer = useTemplateRef<HTMLElement>('chartContainer')
@@ -47,57 +54,28 @@ onMounted(() => {
 
 const colors = useColors(rootEl)
 
-function composeRawDataset(): VueUiXyDatasetItemWithTrends[] {
-  return [
-    {
-      name: 'Organic',
-      series:
-        dates.value?.map(
-          (date) => countsByDate.value?.[date]?.organic.percentage ?? 0,
-        ) ?? [],
-      trends:
-        dates.value?.map(
-          (date) => countsByDate.value?.[date]?.organic.trend ?? 0,
-        ) ?? [],
-      color: colors.value.organic,
-      type: 'line',
-      smooth: true,
-      useArea: true,
-    },
-    {
-      name: 'Mixed',
-      series:
-        dates.value?.map(
-          (date) => countsByDate.value?.[date]?.mixed.percentage ?? 0,
-        ) ?? [],
-      trends:
-        dates.value?.map(
-          (date) => countsByDate.value?.[date]?.mixed.trend ?? 0,
-        ) ?? [],
-      color: colors.value.mixed,
-      type: 'line',
-      smooth: true,
-      useArea: true,
-    },
-    {
-      name: 'Automation',
-      series:
-        dates.value?.map(
-          (date) => countsByDate.value?.[date]?.automation.percentage ?? 0,
-        ) ?? [],
-      trends:
-        dates.value?.map(
-          (date) => countsByDate.value?.[date]?.automation.trend ?? 0,
-        ) ?? [],
-      color: colors.value.automation,
-      type: 'line',
-      smooth: true,
-      useArea: true,
-    },
-  ]
-}
-
-const rawDataset = computed(() => composeRawDataset())
+const rawDataset = computed<EventsEvolutionSeries[]>(() =>
+  CLASSIFICATIONS_WITH_NAME_AND_CATEGORY.map(({ name, category }) => ({
+    name,
+    category,
+    series: (dates.value ?? []).map(
+      (scanTime) => countsByDate.value?.[scanTime]?.[category].percentage ?? 0,
+    ),
+    trends: (dates.value ?? []).map(
+      (scanTime) => countsByDate.value?.[scanTime]?.[category].trend ?? 0,
+    ),
+    counts: (dates.value ?? []).map(
+      (scanTime) => countsByDate.value?.[scanTime]?.[category].count ?? 0,
+    ),
+    totals: (dates.value ?? []).map(
+      (scanTime) => countsByDate.value?.[scanTime]?.total.count ?? 0,
+    ),
+    color: colors.value[category],
+    type: 'line',
+    smooth: true,
+    useArea: true,
+  })),
+)
 
 const max = computed(() => {
   const values = rawDataset.value.flatMap((datasetItem) =>
@@ -375,13 +353,21 @@ function placeLandmark({
               </linearGradient>
             </template>
 
-            <template #tooltip="{ datapoint, timeLabel, series }">
+            <template
+              #tooltip="{ datapoint, timeLabel, series, absoluteIndex }"
+            >
               <div class="flex flex-col tabular-nums">
-                <div :style="{ color: colors.textMuted }" class="mb-1">
-                  {{ timeLabel.text }}
-                </div>
+                <ChartEventsEvolutionTooltipHeader
+                  :timeLabel="timeLabel.text"
+                  :count="
+                    getTotalPrScanned(
+                      series as VueUiXySeriesWithCounts,
+                      absoluteIndex,
+                    )
+                  "
+                />
 
-                <EventsEvolutionTooltipTable
+                <ChartEventsEvolutionTooltipTable
                   :tooltip-slot-props="{ datapoint, timeLabel, series }"
                   :colors
                   :can-compare="timeLabel.absoluteIndex > 0"
@@ -391,7 +377,7 @@ function placeLandmark({
                     <th class="px-2 text-center">vs Day-1</th>
                     <th class="px-2 text-left">Trend</th>
                   </template>
-                </EventsEvolutionTooltipTable>
+                </ChartEventsEvolutionTooltipTable>
 
                 <!-- LANDMARK INFO -->
                 <div

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -10,7 +10,14 @@ import { useElementSize } from '@vueuse/core'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { round } from '~~/shared/utils/numbers'
-import EventsEvolutionTooltipTable from './EventsEvolutionTooltipTable.vue'
+import type {
+  EventsEvolutionSeries,
+  VueUiXySeriesWithCounts,
+} from '~~/shared/types/ecosystem-health.ts'
+import {
+  CLASSIFICATIONS_WITH_NAME_AND_CATEGORY,
+  getTotalPrScanned,
+} from '~~/shared/utils/charts.ts'
 
 dayjs.extend(utc)
 
@@ -47,34 +54,8 @@ const hasStableChartDimensions = computed(
   () => width.value > 0 && height.value > 0,
 )
 
-type HourlySerie = VueUiXyDatasetItem & {
-  category: EcosystemHealthCategory
-  trends: number[]
-  counts: number[]
-  totals: number[]
-}
-
-const classifications: Array<{
-  name: string
-  category: EcosystemHealthCategory
-}> = [
-  { name: 'Organic', category: 'organic' },
-  { name: 'Mixed', category: 'mixed' },
-  { name: 'Automation', category: 'automation' },
-]
-
-function getSerieColor(category: EcosystemHealthCategory) {
-  if (category === 'organic') {
-    return colors.value.organic
-  }
-  if (category === 'mixed') {
-    return colors.value.mixed
-  }
-  return colors.value.automation
-}
-
-const rawDataset = computed<HourlySerie[]>(() =>
-  classifications.map(({ name, category }) => ({
+const rawDataset = computed<EventsEvolutionSeries[]>(() =>
+  CLASSIFICATIONS_WITH_NAME_AND_CATEGORY.map(({ name, category }) => ({
     name,
     category,
     series: (scanTimes.value ?? []).map(
@@ -90,7 +71,7 @@ const rawDataset = computed<HourlySerie[]>(() =>
     totals: (scanTimes.value ?? []).map(
       (scanTime) => countsByScanTime.value?.[scanTime]?.total.count ?? 0,
     ),
-    color: getSerieColor(category),
+    color: colors.value[category],
     type: 'line',
     smooth: true,
     useArea: true,
@@ -282,11 +263,19 @@ function handleChartMouseleave() {
               </linearGradient>
             </template>
 
-            <template #tooltip="{ datapoint, timeLabel, series }">
-              <div class="flex flex-col">
-                <div :style="{ color: colors.textMuted }" class="mb-1">
-                  {{ formatScanTime(timeLabel.absoluteIndex) }}
-                </div>
+            <template
+              #tooltip="{ datapoint, timeLabel, series, absoluteIndex }"
+            >
+              <div class="flex flex-col tabular-nums">
+                <ChartEventsEvolutionTooltipHeader
+                  :timeLabel="formatScanTime(timeLabel.absoluteIndex)"
+                  :count="
+                    getTotalPrScanned(
+                      series as VueUiXySeriesWithCounts,
+                      absoluteIndex,
+                    )
+                  "
+                />
 
                 <!-- TODO: dedicated tooltip component for the repo drill view -->
                 <!-- NOTE: it should have an equivalent width as the regular tooltip to avoid a big shift when toggling, because the tooltip will keep the same coordinates when its content changes -->
@@ -298,7 +287,7 @@ function handleChartMouseleave() {
                   {{ datapoint }}
                 </div>
 
-                <EventsEvolutionTooltipTable
+                <ChartEventsEvolutionTooltipTable
                   v-else
                   :tooltip-slot-props="{ datapoint, timeLabel, series }"
                   :colors
@@ -309,7 +298,7 @@ function handleChartMouseleave() {
                     <th class="px-2 text-center">vs Hour-1</th>
                     <th class="px-2 text-left">Trend</th>
                   </template>
-                </EventsEvolutionTooltipTable>
+                </ChartEventsEvolutionTooltipTable>
               </div>
             </template>
 

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -268,7 +268,7 @@ function handleChartMouseleave() {
             >
               <div class="flex flex-col tabular-nums">
                 <ChartEventsEvolutionTooltipHeader
-                  :timeLabel="formatScanTime(timeLabel.absoluteIndex)"
+                  :time-label="formatScanTime(timeLabel.absoluteIndex)"
                   :count="
                     getTotalPrScanned(
                       series as VueUiXySeriesWithCounts,

--- a/shared/types/ecosystem-health.ts
+++ b/shared/types/ecosystem-health.ts
@@ -1,4 +1,4 @@
-import type { VueUiXyDatasetItem } from 'vue-data-ui/vue-ui-xy'
+import type { VueUiXyDatasetItem, VueUiXySeries } from 'vue-data-ui/vue-ui-xy'
 import type { calcLinearProgression } from '../utils/calc-linear-progression'
 import type { IdentityClassification } from '@unveil/identity'
 
@@ -36,4 +36,15 @@ export type EcosystemHealthCategoryProgression = Record<
 
 export type VueUiXyDatasetItemWithTrends = VueUiXyDatasetItem & {
   trends: number[]
+}
+
+export type VueUiXySeriesWithCounts = Array<
+  VueUiXySeries & { counts: number[] }
+>
+
+export type EventsEvolutionSeries = VueUiXyDatasetItem & {
+  category: EcosystemHealthCategory
+  trends: number[]
+  counts: number[]
+  totals: number[]
 }

--- a/shared/utils/charts.ts
+++ b/shared/utils/charts.ts
@@ -1,3 +1,5 @@
+import type { VueUiXySeriesWithCounts } from '../types/ecosystem-health'
+
 export function getCompleteDayRange(days: string[]): string[] {
   if (!days.length) {
     return []
@@ -54,4 +56,23 @@ export const SVG_ICON = {
   info: `<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>`,
   newspaper: `<path d="M15 18h-5"/><path d="M18 14h-8"/><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16a2 2 0 0 1-4 0v-9a2 2 0 0 1 2-2h2"/><rect stroke="currentColor" width="8" height="4" x="10" y="6" rx="1"/>`,
   shieldCheck: `<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/>`,
+}
+
+export const CLASSIFICATIONS_WITH_NAME_AND_CATEGORY: Array<{
+  name: string
+  category: EcosystemHealthCategory
+}> = [
+  { name: 'Organic', category: 'organic' },
+  { name: 'Mixed', category: 'mixed' },
+  { name: 'Automation', category: 'automation' },
+]
+
+export function getTotalPrScanned(
+  items: VueUiXySeriesWithCounts,
+  absoluteIndex: number,
+): number {
+  const totals = items
+    .map((item) => item.counts[absoluteIndex])
+    .reduce((a, b) => (a ?? 0) + (b ?? 0), 0)
+  return totals ?? 0
 }


### PR DESCRIPTION
This adds the PR count in the health chart tooltips, and refactors both chart components with shared logic and types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chart tooltips with clearer timestamps and total pull requests scanned.
  * Added detailed counts and totals for each event classification.
  * Chart series and colors now reflect shared classification categories consistently.

* **Bug Fixes**
  * Improved handling of missing chart data when calculating totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->