### PR TITLE
fix: do not wait for the data to mount health chart components

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -21,7 +21,7 @@ import {
   getTotalPrScanned,
 } from '~~/shared/utils/charts.ts'
 
-const { data: ecosystemHealth } = await useEcosystemHealth()
+const { data: ecosystemHealth } = useEcosystemHealth()
 
 const chartContainer = useTemplateRef<HTMLElement>('chartContainer')
 const { width, height } = useElementSize(chartContainer)

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -23,7 +23,7 @@ dayjs.extend(utc)
 
 import('vue-data-ui/style.css')
 
-const { data: hourlyWindow } = await useEcosystemHealthHourlyWindow()
+const { data: hourlyWindow } = useEcosystemHealthHourlyWindow()
 
 const rootEl = shallowRef<HTMLElement | null>(null)
 const colors = useColors(rootEl)


### PR DESCRIPTION
This just removes the await on the health chart components' data composable, which prevented the components from mounting until resolve. Applied on both health chart components.
Transitioning from daily to hourly should now be (more) snappy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved chart loading responsiveness by allowing event data to initialize without blocking component setup.
  * Preserved reactive access to global and hourly event data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->