### PR TITLE
fix(gh-app): action hangs when pr is open by a bot

### DIFF
--- a/server/api/webhook/github.post.test.ts
+++ b/server/api/webhook/github.post.test.ts
@@ -399,6 +399,26 @@ describe('GitHub Webhook Handler', () => {
       )
     })
 
+    it('percent-encodes the bot login in the check run details_url', async () => {
+      setupEvent({
+        pull_request: {
+          number: 123,
+          user: { login: 'dependabot[bot]' },
+          head: { sha: 'abc123' },
+        },
+      })
+
+      await handler(MOCK_EVENT)
+
+      // Raw brackets make `details_url` an invalid URL, GitHub rejects the
+      // update, and the check run stays stuck in progress.
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details_url: 'https://agentscan.tools/user/dependabot%5Bbot%5D',
+        }),
+      )
+    })
+
     it('returns { ok: true } without scanning for usernames ending with [bot]', async () => {
       setupEvent({
         pull_request: { number: 123, user: { login: 'some-custom-tool[bot]' } },
@@ -1726,24 +1746,50 @@ describe('GitHub Webhook Handler', () => {
       onTestFinished(() => consoleError.mockRestore())
 
       await expect(handler(MOCK_EVENT)).resolves.toMatchObject({ ok: true })
-      // No retry of the real conclusion, but the run must not be left at
-      // `in_progress`: the guard concludes it as neutral instead.
+      // Each conclusion is attempted twice — full payload, then stripped — and
+      // the run must not be left at `in_progress`: once the real conclusion is
+      // exhausted the guard concludes it as neutral instead.
       expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
-        2,
+        4,
       )
       expect(
         mockInstallationOctokit.rest.checks.update,
       ).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          conclusion: 'neutral',
-          output: expect.objectContaining({ title: 'Analysis incomplete' }),
-        }),
+        expect.objectContaining({ status: 'completed', conclusion: 'neutral' }),
       )
-      expect(consoleError).toHaveBeenCalledTimes(2)
       expect(consoleError).toHaveBeenLastCalledWith(
-        expect.stringContaining('Failed to complete check run'),
+        expect.stringContaining('without output'),
         expect.any(Error),
       )
+    })
+
+    it('completes the check run without output when GitHub rejects the payload', async () => {
+      mockInstallationOctokit.rest.checks.update
+        .mockRejectedValueOnce(new Error('422 Invalid request'))
+        .mockResolvedValue({ data: {} })
+
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {})
+      onTestFinished(() => consoleError.mockRestore())
+
+      await expect(handler(MOCK_EVENT)).resolves.toMatchObject({ ok: true })
+
+      // The stripped retry lands the real conclusion, so the safety net in
+      // `finally` sees a settled run and does not overwrite it with neutral.
+      expect(mockInstallationOctokit.rest.checks.update).toHaveBeenCalledTimes(
+        2,
+      )
+
+      const stripped =
+        mockInstallationOctokit.rest.checks.update.mock.calls[1]![0]
+
+      expect(stripped).toMatchObject({
+        status: 'completed',
+        conclusion: 'success',
+      })
+      expect(stripped).not.toHaveProperty('output')
+      expect(stripped).not.toHaveProperty('details_url')
     })
 
     it('concludes the check run as neutral when the analysis outruns the deadline', async () => {

--- a/server/api/webhook/github/index.post.ts
+++ b/server/api/webhook/github/index.post.ts
@@ -33,6 +33,12 @@ type OctokitAuthInstall = { token?: string } | undefined
 // check run before the process is killed.
 const CHECK_RUN_DEADLINE_MS = 8_000
 
+// Bot logins carry square brackets (`dependabot[bot]`), which are not legal in
+// a URL path. Left raw, GitHub rejects `details_url` and the check run never
+// gets a result.
+const profileUrl = (username: string) =>
+  `https://agentscan.tools/user/${encodeURIComponent(username)}`
+
 type AutomationListItem = {
   username: string
   reason: string
@@ -324,22 +330,39 @@ export default defineEventHandler(async (event) => {
     // is still waiting for GitHub skips instead of sending a second result.
     isCheckRunSettled = true
 
+    // Reporting a result is the only way out of `in_progress`: GitHub never
+    // expires a check run on its own, so whatever goes wrong here, the run has
+    // to end with a conclusion or it blocks the PR forever.
+    const result = {
+      owner,
+      repo,
+      check_run_id: checkRunId,
+      status: 'completed' as const,
+      conclusion,
+      completed_at: new Date().toISOString(),
+    }
+
     try {
       await octokit.rest.checks.update({
-        owner,
-        repo,
-        check_run_id: checkRunId,
-        status: 'completed',
-        conclusion,
-        completed_at: new Date().toISOString(),
-        details_url: `https://agentscan.tools/user/${username}`,
+        ...result,
+        details_url: profileUrl(username),
         output: { title, summary },
       })
+      return
     } catch (err: unknown) {
-      // The check run still has no result, so let a later call try again.
-      isCheckRunSettled = false
       console.error(
         `Failed to complete check run ${checkRunId} on ${owner}/${repo}:`,
+        err,
+      )
+    }
+
+    // unblocks the PR
+    try {
+      await octokit.rest.checks.update(result)
+    } catch (err: unknown) {
+      isCheckRunSettled = false
+      console.error(
+        `Failed to complete check run ${checkRunId} on ${owner}/${repo} without output:`,
         err,
       )
     }
@@ -561,7 +584,7 @@ export default defineEventHandler(async (event) => {
       '',
       description,
       '',
-      `[View full analysis →](https://agentscan.tools/user/${username})`,
+      `[View full analysis →](${profileUrl(username)})`,
       ...(reportUrl ? ['', `[Report this account →](${reportUrl})`] : []),
       ...(evidenceLines.length > 0
         ? [


### PR DESCRIPTION
closes #392 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile links for bot accounts and usernames containing special characters.
  * Improved GitHub check-run completion by retrying with a simplified update when the initial update is rejected.
  * Ensured check runs receive a final conclusion when possible, while preserving the intended result after a successful retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->