### PR TITLE
feat: add myself as reviewer

### DIFF
--- a/.github/workflows/review-automation-issues.yml
+++ b/.github/workflows/review-automation-issues.yml
@@ -39,6 +39,7 @@ env:
     TheAlexLichter
     orbisk
     bluwy
+    trueberryless
 
   MIN_APPROVALS: '4'
   MIN_REJECTIONS: '2'


### PR DESCRIPTION
Sneeky little PR to add myself to The Rosen Association. Not sure if there is some process to be accepted, I have just been giving some reactions and read the comment that only reactions from these accounts are considered. hehe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated review automation to include an additional reviewer in the review rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->