### PR TITLE
chore(deps): bump vue-data-ui from 3.23.12 to 3.25.0

### DIFF
--- a/app/components/Chart/AccountEventsTimeline.vue
+++ b/app/components/Chart/AccountEventsTimeline.vue
@@ -44,7 +44,10 @@ function selectLegend(items: Array<{ color: string; name: string }>) {
 }
 
 const eventConfig = computed(() => {
-  const classification = props.classification || 'mixed'
+  const classification = (props.classification || 'mixed') as Exclude<
+    IdentityClassification,
+    'insufficient-data'
+  >
   const palette = {
     organic: {
       pr: colors.value.eventOrganicPr,
@@ -373,6 +376,8 @@ const xAxisLabelValues = computed<string[]>(() => {
 
 const tooltipPositionLine = useTooltipPosition(chartLineRef)
 
+const XAXIS_LABELS_MOD_THRESHOLD = 12
+
 const configLine = computed<VueUiXyConfig>(() => ({
   downsample: {
     threshold: 5000,
@@ -414,8 +419,15 @@ const configLine = computed<VueUiXyConfig>(() => ({
           show: true,
           color: colors.value.textMuted,
           values: xAxisLabelValues.value,
-          showOnlyAtModulo: !usesHourlyGranularity.value,
-          modulo: 12,
+          showOnlyAtModulo:
+            !usesHourlyGranularity.value &&
+            xAxisLabelValues.value.length > XAXIS_LABELS_MOD_THRESHOLD,
+          modulo: Math.max(
+            1,
+            Math.round(
+              xAxisLabelValues.value.length / XAXIS_LABELS_MOD_THRESHOLD,
+            ),
+          ),
           rotation: -30,
           autoRotate: { enable: false },
           datetimeFormatter: { enable: false },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.4.2",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.23.12",
+    "vue-data-ui": "^3.25.0",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.23.12
-        version: 3.23.12(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.25.0
+        version: 3.25.0(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -5883,8 +5883,8 @@ packages:
   vue-bundle-renderer@2.3.1:
     resolution: {integrity: sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==}
 
-  vue-data-ui@3.23.12:
-    resolution: {integrity: sha512-BxSY7Gs1WE6wARJI0aTrolZSxE9CXFoPXjuE5qK1hLtMZ96N34P7UNmSa8MW62FrNBgciyOQ2HWZg/hVZ2H/0g==}
+  vue-data-ui@3.25.0:
+    resolution: {integrity: sha512-xVbeb6OXb7G9aAbO0GGdWPdyibl7jW4cuIuvB55T8JvEgT15Ns85BjtkmxrAq3ZIfAq9mFUJp7FZAvSBSfLlsQ==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -12370,7 +12370,7 @@ snapshots:
     dependencies:
       ufo: 1.6.4
 
-  vue-data-ui@3.23.12(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.25.0(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 


### PR DESCRIPTION
- Bump vue-data-ui to latest minor, with adaptations following a minor breaking change (see [release notes](https://github.com/graphieros/vue-data-ui/releases/tag/v3.25.0)).
- a TS fix _en passant_ because I'm a boi scout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart classification handling for supported identity types.
  * Improved X-axis label readability for long daily timelines while retaining all labels on hourly charts.

* **Updates**
  * Updated the charting component version to 3.25.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->