### PR TITLE
fix: hide zoom range input from repo-score history chart

### DIFF
--- a/app/components/Chart/RepoScoreHistory.vue
+++ b/app/components/Chart/RepoScoreHistory.vue
@@ -236,6 +236,9 @@ const configLine = computed<VueUiXyConfig>(() => ({
       offsetX: 24,
       offsetY: -32,
     },
+    zoom: {
+      show: false,
+    },
   },
 }))
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled zoom controls on the repository score history chart for a simpler viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->