### PR TITLE
chore: bump vue-data-ui to latest & a fix en passant

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -359,8 +359,8 @@ function placeLandmark({
                     <text
                       :fill="colors.textMuted"
                       :stroke="colors.bg"
-                      :opacity="isChartHovered ? 0.6 : 0"
-                      stroke-width="3"
+                      :opacity="isChartHovered ? 1 : 0"
+                      stroke-width="8"
                       stroke-linecap="round"
                       stroke-linejoin="round"
                       :font-size="LANDMARK_LABEL_FONT_SIZE"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.4.2",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.25.0",
+    "vue-data-ui": "^3.25.4",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.25.0
-        version: 3.25.0(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.25.4
+        version: 3.25.4(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -6422,8 +6422,8 @@ packages:
   vue-component-type-helpers@3.3.11:
     resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
 
-  vue-data-ui@3.25.0:
-    resolution: {integrity: sha512-xVbeb6OXb7G9aAbO0GGdWPdyibl7jW4cuIuvB55T8JvEgT15Ns85BjtkmxrAq3ZIfAq9mFUJp7FZAvSBSfLlsQ==}
+  vue-data-ui@3.25.4:
+    resolution: {integrity: sha512-fJExip0mhLeNagZzd9gz7wUN1aIR7CoE6iQAKppwBIlm92yisUPqytP5d2mbJK23R3vwObABIjfuSyimVP3Mlw==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -13764,7 +13764,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.11: {}
 
-  vue-data-ui@3.25.0(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.25.4(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 


### PR DESCRIPTION
- Bump vue-data-ui to latest (no impact for our usage)
- Special OCD fix in the ecosystem activity charts:

BEFORE | AFTER
<img width="1280" height="412" alt="image" src="https://github.com/user-attachments/assets/0203a5e5-81ce-4aea-8e0e-2d403efe5f96" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart landmark label visibility when hovered by increasing contrast and stroke width.

- **Improvements**
  - Updated the charting component dependency to a newer version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->