### PR TITLE
feat: add circle marker to the volume line when hovered

### DIFF
--- a/app/components/Chart/GlobalEventsEvolution.vue
+++ b/app/components/Chart/GlobalEventsEvolution.vue
@@ -119,7 +119,15 @@ const viewBoxPadding = computed(() => {
 
 const tooltipTimeFormat = 'dddd • MMM dd • HH:mm'
 
+const hoveredIndex = ref<number | null>(null)
+
 const config = computed<VueUiXyConfig>(() => ({
+  events: {
+    datapointEnter: ({ seriesIndex }) => {
+      hoveredIndex.value = seriesIndex
+    },
+    datapointLeave: () => (hoveredIndex.value = null),
+  },
   useCssAnimation: false,
   downsample: {
     threshold: 5000,
@@ -340,8 +348,10 @@ function placeLandmark({
                 :svg
                 :counts="prCounts"
                 :color="colors.textMuted"
+                :background-color="colors.bg"
                 :visible="isChartHovered || isMobile"
                 :stroke-width="isMobile ? 1.5 : 2"
+                :hovered-index="hoveredIndex"
               />
 
               <!-- LANDMARKS -->

--- a/app/components/Chart/HourlyEventsEvolution.vue
+++ b/app/components/Chart/HourlyEventsEvolution.vue
@@ -117,7 +117,15 @@ const hasSingleEntry = computed(() => dataset.value[0]?.series.length === 1)
 
 const axisTimeFormat = 'HH:mm'
 
+const hoveredIndex = ref<number | null>(null)
+
 const config = computed<VueUiXyConfig>(() => ({
+  events: {
+    datapointEnter: ({ seriesIndex }) => {
+      hoveredIndex.value = seriesIndex
+    },
+    datapointLeave: () => (hoveredIndex.value = null),
+  },
   useCssAnimation: false,
   transitions: {
     enable: ready.value,
@@ -292,8 +300,10 @@ function handleChartMouseleave() {
                 :svg
                 :counts="prCounts"
                 :color="colors.textMuted"
+                :background-color="colors.bg"
                 :visible="isChartHovered || isMobile"
                 :stroke-width="isMobile ? 1.5 : 2"
+                :hovered-index="hoveredIndex"
               />
 
               <text

--- a/app/components/Chart/PrVolumeLine.vue
+++ b/app/components/Chart/PrVolumeLine.vue
@@ -10,8 +10,10 @@ const props = withDefaults(
     svg: VueUiXySvgSlotProps['svg']
     counts: number[]
     color: string
+    backgroundColor: string
     visible?: boolean
     strokeWidth?: number
+    hoveredIndex: number | null
   }>(),
   {
     visible: false,
@@ -23,25 +25,32 @@ const props = withDefaults(
 // Pretty much visual tweaking
 const PEAK_HEIGHT_RATIO = 0.85
 
-const points = computed(() => {
+const plotCoordinates = computed(() => {
   const plots = props.svg.data?.[0]?.plots ?? []
   const sliceStart = props.svg.slicer?.start ?? 0
   const maxCount = props.counts.length ? Math.max(...props.counts) : 0
 
   if (plots.length < 2 || maxCount <= 0) {
-    return ''
+    return null
   }
 
   const { bottom, height } = props.svg.drawingArea
 
-  return plots
-    .map((plot, index) => {
-      const count = props.counts[index + sliceStart] ?? 0
-      const y = bottom - (count / maxCount) * height * PEAK_HEIGHT_RATIO
-      return `${plot.x},${y}`
-    })
-    .join(' ')
+  return plots.map((plot, index) => {
+    const count = props.counts[index + sliceStart] ?? 0
+    const y = bottom - (count / maxCount) * height * PEAK_HEIGHT_RATIO
+    return {
+      x: plot.x,
+      y,
+    }
+  })
 })
+
+const points = computed(() =>
+  plotCoordinates.value === null
+    ? ''
+    : plotCoordinates.value.map(({ x, y }) => `${x},${y}`).join(' '),
+)
 </script>
 
 <template>
@@ -56,6 +65,15 @@ const points = computed(() => {
     :stroke-dasharray="PR_VOLUME_DASH_ARRAY"
     :opacity="visible ? 0.75 : 0"
     class="pr-volume-line"
+  />
+  <circle
+    v-if="hoveredIndex !== null && plotCoordinates !== null"
+    :cx="plotCoordinates[hoveredIndex]?.x"
+    :cy="plotCoordinates[hoveredIndex]?.y"
+    :r="4.5"
+    :fill="color"
+    :stroke="backgroundColor"
+    stroke-width="2"
   />
 </template>
 


### PR DESCRIPTION
This adds a circle marker on the coordinates of the selected index of the volume line of the ecosystem activity charts on hover.

<img width="165" height="293" alt="image" src="https://github.com/user-attachments/assets/3bcefec5-74a7-4295-b3be-afbe06f399ed" />
