### PR TITLE
refactor: add validation to endpoint

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -148,12 +148,12 @@ export default defineNuxtConfig({
         maxAge: 60 * 5,
       },
     },
+
     '/api/scan/**': {
       isr: {
         expiration: 60 * 10,
         passQuery: true,
       },
-      cache: { maxAge: 600 },
     },
     '/feed.xml': {
       cache: {

--- a/server/api/scan.get.ts
+++ b/server/api/scan.get.ts
@@ -1,6 +1,7 @@
 import { identify, isGitHubAppAccount } from '@unveil/identity'
 import { parseRepoSlug } from '~~/shared/utils/parse-repo-slug'
 import { MAX_PR_COUNT } from '~~/shared/scan'
+import type { H3Event } from 'h3'
 import type { Endpoints } from '@octokit/types'
 
 export type AuthorAssociation =
@@ -22,132 +23,165 @@ type PullRequestEntry = {
   state: string
 }
 
-export default defineEventHandler(async (event) => {
-  const config = useRuntimeConfig()
-  const query = getQuery(event)
-  const repoInput = String(query.repo ?? '')
+function getScanTarget(event: H3Event) {
+  return parseRepoSlug(String(getQuery(event).repo ?? ''))
+}
 
-  if (!repoInput) {
-    throw createError({ statusCode: 400, message: 'Missing repo parameter' })
+async function analyzeAuthor(
+  octokit: ReturnType<typeof createOctokit>,
+  login: string,
+) {
+  const [profileRes, eventResponses] = await Promise.all([
+    octokit.rest.users.getByUsername({ username: login }),
+    Promise.all(
+      Array.from({ length: EVENT_PAGES }, (_, i) =>
+        octokit.rest.activity.listPublicEventsForUser({
+          username: login,
+          per_page: 100,
+          page: i + 1,
+        }),
+      ),
+    ),
+  ])
+
+  const user = profileRes.data
+  const events = eventResponses.flatMap((r) => r.data)
+
+  return {
+    user,
+    analysis: identify({ user, events }),
+    eventsCount: events.length,
   }
+}
 
-  const parsed = parseRepoSlug(repoInput)
-  if (!parsed) {
-    throw createError({
-      statusCode: 400,
-      message:
-        'Invalid repository. Expected format: owner/repo or https://github.com/owner/repo',
-    })
-  }
+export default defineCachedEventHandler(
+  async (event) => {
+    const config = useRuntimeConfig()
+    const repoInput = String(getQuery(event).repo ?? '')
 
-  const { owner, repo } = parsed
-  const octokit = createOctokit(config.githubToken)
+    if (!repoInput) {
+      throw createError({ statusCode: 400, message: 'Missing repo parameter' })
+    }
 
-  const pullRequests: PullRequestEntry[] = []
-
-  try {
-    for (
-      let page = 1;
-      page <= MAX_PAGES && pullRequests.length < MAX_PR_COUNT;
-      page++
-    ) {
-      const { data: prs } = await octokit.rest.pulls.list({
-        owner,
-        repo,
-        state: 'all',
-        sort: 'created',
-        direction: 'desc',
-        per_page: PER_PAGE,
-        page,
+    const parsed = getScanTarget(event)
+    if (!parsed) {
+      throw createError({
+        statusCode: 400,
+        message:
+          'Invalid repository. Expected format: owner/repo or https://github.com/owner/repo',
       })
+    }
 
-      for (const pr of prs) {
-        if (pullRequests.length >= MAX_PR_COUNT) {
+    const { owner, repo } = parsed
+    const octokit = createOctokit(config.githubToken)
+
+    const pullRequests: PullRequestEntry[] = []
+
+    try {
+      for (
+        let page = 1;
+        page <= MAX_PAGES && pullRequests.length < MAX_PR_COUNT;
+        page++
+      ) {
+        const { data: prs } = await octokit.rest.pulls.list({
+          owner,
+          repo,
+          state: 'all',
+          sort: 'created',
+          direction: 'desc',
+          per_page: PER_PAGE,
+          page,
+        })
+
+        for (const pr of prs) {
+          if (pullRequests.length >= MAX_PR_COUNT) {
+            break
+          }
+
+          if (!pr.user?.login) {
+            continue
+          }
+
+          if (isGitHubAppAccount(pr.user)) {
+            continue
+          }
+
+          if (TRUSTED_ASSOCIATIONS.includes(pr.author_association)) {
+            continue
+          }
+
+          const username = pr.user.login.toLowerCase()
+
+          pullRequests.push({
+            login: username,
+            prUrl: pr.html_url,
+            state: pr.state,
+          })
+        }
+
+        if (prs.length < PER_PAGE) {
           break
         }
-
-        if (!pr.user?.login) {
-          continue
-        }
-
-        if (isGitHubAppAccount(pr.user)) {
-          continue
-        }
-
-        if (TRUSTED_ASSOCIATIONS.includes(pr.author_association)) {
-          continue
-        }
-
-        const username = pr.user.login.toLowerCase()
-
-        pullRequests.push({
-          login: username,
-          prUrl: pr.html_url,
-          state: pr.state,
-        })
       }
 
-      if (prs.length < PER_PAGE) {
-        break
-      }
-    }
+      // One author often holds several of the last PRs on a busy repository.
+      // Their profile and event history are the same every time, so analyzing
+      // them once keeps a duplicate from spending another four requests.
+      const uniqueLogins = [...new Set(pullRequests.map((pr) => pr.login))]
 
-    const results = await Promise.all(
-      pullRequests.map(async (entry) => {
-        const [profileRes, eventResponses] = await Promise.all([
-          octokit.rest.users.getByUsername({ username: entry.login }),
-          Promise.all(
-            Array.from({ length: EVENT_PAGES }, (_, i) =>
-              octokit.rest.activity.listPublicEventsForUser({
-                username: entry.login,
-                per_page: 100,
-                page: i + 1,
-              }),
-            ),
+      const analyzed = new Map(
+        await Promise.all(
+          uniqueLogins.map(
+            async (login) =>
+              [login, await analyzeAuthor(octokit, login)] as const,
           ),
-        ])
+        ),
+      )
 
-        const user = profileRes.data
-        const events = eventResponses.flatMap((r) => r.data)
+      const results = pullRequests
+        .map((entry) => {
+          const author = analyzed.get(entry.login)
 
-        const analysis = identify({
-          user,
-          events,
+          if (!author) {
+            return null
+          }
+
+          return {
+            ...author,
+            prUrl: entry.prUrl,
+            prState: entry.state,
+          }
         })
+        .filter((result) => result !== null)
 
-        return {
-          user,
-          analysis,
-          prUrl: entry.prUrl,
-          prState: entry.state,
-          eventsCount: events.length,
-        }
-      }),
-    )
+      results.sort((a, b) => {
+        return a.analysis.score - b.analysis.score
+      })
 
-    results.sort((a, b) => {
-      return a.analysis.score - b.analysis.score
-    })
+      return { pullRequests: results, repo: `${owner}/${repo}` }
+    } catch (err: unknown) {
+      const error = err as { status?: number; statusCode?: number }
+      const status = error.status ?? error.statusCode
 
-    return { pullRequests: results, repo: `${owner}/${repo}` }
-  } catch (err: unknown) {
-    const error = err as { status?: number; statusCode?: number }
-    const status = error.status ?? error.statusCode
+      if (status === 403) {
+        throw createError({
+          statusCode: 429,
+          message: 'GitHub API rate limit reached. Please try again later.',
+        })
+      }
 
-    if (status === 403) {
+      if (status === 404) {
+        throw createError({ statusCode: 404, message: 'Repository not found' })
+      }
+
       throw createError({
-        statusCode: 429,
-        message: 'GitHub API rate limit reached. Please try again later.',
+        statusCode: 500,
+        message: 'Failed to fetch repository data from GitHub',
       })
     }
-
-    if (status === 404) {
-      throw createError({ statusCode: 404, message: 'Repository not found' })
-    }
-
-    throw createError({
-      statusCode: 500,
-      message: 'Failed to fetch repository data from GitHub',
-    })
-  }
-})
+  },
+  {
+    maxAge: 60 * 10,
+    getKey: (event) => getScanTarget(event)?.path.toLowerCase() ?? 'invalid',
+  },
+)

--- a/server/api/webhook/github/_config.test.ts
+++ b/server/api/webhook/github/_config.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_CONFIG,
+  MAX_MESSAGE_LENGTH,
+  parseRepoConfig,
+  SUPPORTED_CONFIG_VERSION,
+} from './_config'
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+describe('DEFAULT_CONFIG', () => {
+  it('is the documented shape', () => {
+    expect(DEFAULT_CONFIG).toEqual({
+      version: SUPPORTED_CONFIG_VERSION,
+      'allowed-users': [],
+      'trusted-author-associations': [],
+      'auto-close': false,
+      'auto-close-classifications': ['automation'],
+      honeypot: false,
+      mode: 'full',
+      'comment-on-organic': false,
+      scan: { 'pull-requests': true, issues: false },
+      labels: {
+        'community-flagged': 'agentscan:community-flagged',
+        mixed: 'agentscan:mixed-signals',
+        automation: 'agentscan:automation-signals',
+      },
+      messages: {
+        organic: '',
+        mixed: '',
+        automation: '',
+        'insufficient-data': '',
+        'community-flagged': '',
+        honeypot: '',
+        'honeypot-first-time': '',
+      },
+    })
+  })
+})
+
+describe('parseRepoConfig', () => {
+  it('reads a valid file', () => {
+    const config = parseRepoConfig(`
+mode: comment
+honeypot: true
+auto-close: true
+allowed-users:
+  - dependabot
+scan:
+  issues: true
+`)
+
+    expect(config.mode).toBe('comment')
+    expect(config.honeypot).toBe(true)
+    expect(config['auto-close']).toBe(true)
+    expect(config['allowed-users']).toEqual(['dependabot'])
+    // Untouched keys of a partially written section keep their defaults.
+    expect(config.scan).toEqual({ 'pull-requests': true, issues: true })
+  })
+
+  it.each([
+    ['empty', ''],
+    ['comments only', '# nothing here'],
+    ['a bare scalar', 'just a string'],
+    ['a list', '- one\n- two'],
+    ['malformed YAML', 'mode: [unclosed'],
+  ])('falls back to defaults for %s', (_label, input) => {
+    expect(parseRepoConfig(input)).toEqual(DEFAULT_CONFIG)
+  })
+
+  it('ignores a file written for a newer version', () => {
+    const config = parseRepoConfig(
+      `version: ${SUPPORTED_CONFIG_VERSION + 1}\nmode: silent`,
+    )
+
+    expect(config).toEqual(DEFAULT_CONFIG)
+    expect(config.mode).toBe('full')
+  })
+
+  describe('rejects values that used to be passed through unread', () => {
+    // `mode: FULL` matched none of the mode branches, so the app silently
+    // stopped commenting and labelling instead of using the default.
+    it.each(['FULL', 'silnet', 'Comment', 42, null, ['full']])(
+      'falls back to the default mode for %o',
+      (mode) => {
+        expect(parseRepoConfig(`mode: ${JSON.stringify(mode)}`).mode).toBe(
+          'full',
+        )
+      },
+    )
+
+    // A string has `.includes`, so `allowed-users: evil` exempted every author
+    // whose login was a substring of it.
+    it('does not accept a string as the allow list', () => {
+      const config = parseRepoConfig('allowed-users: evilmaintainer')
+
+      expect(config['allowed-users']).toEqual([])
+      expect(config['allowed-users'].includes('evil')).toBe(false)
+    })
+
+    // A number has no `.includes` at all, which threw and failed the check run.
+    it('does not accept a number as the allow list', () => {
+      expect(parseRepoConfig('allowed-users: 5')['allowed-users']).toEqual([])
+    })
+
+    it('drops non-string entries from the allow list', () => {
+      expect(
+        parseRepoConfig('allowed-users:\n  - ok\n  - 5')['allowed-users'],
+      ).toEqual([])
+    })
+
+    it('rejects an unknown author association', () => {
+      expect(
+        parseRepoConfig(
+          'trusted-author-associations:\n  - owner\n  - EVERYONE',
+        )['trusted-author-associations'],
+      ).toEqual([])
+    })
+
+    it('rejects an unknown auto-close classification', () => {
+      expect(
+        parseRepoConfig('auto-close-classifications:\n  - everything')[
+          'auto-close-classifications'
+        ],
+      ).toEqual(['automation'])
+    })
+
+    it.each(['auto-close', 'honeypot', 'comment-on-organic'])(
+      'rejects a non-boolean %s',
+      (key) => {
+        expect(parseRepoConfig(`${key}: yes please`)).toMatchObject({
+          [key]: false,
+        })
+      },
+    )
+
+    it('rejects a scalar where a section belongs', () => {
+      expect(parseRepoConfig('scan: everything').scan).toEqual(
+        DEFAULT_CONFIG.scan,
+      )
+    })
+  })
+
+  describe('custom messages', () => {
+    it('keeps a message within the cap', () => {
+      expect(
+        parseRepoConfig('messages:\n  automation: Please explain').messages
+          .automation,
+      ).toBe('Please explain')
+    })
+
+    // The comment goes out under this app's name, so an unbounded message is
+    // not passed through.
+    it('drops a message over the cap', () => {
+      const config = parseRepoConfig(
+        `messages:\n  automation: "${'x'.repeat(MAX_MESSAGE_LENGTH + 1)}"`,
+      )
+
+      expect(config.messages.automation).toBe('')
+    })
+
+    it('drops only the offending message', () => {
+      const config = parseRepoConfig(
+        `messages:\n  automation: 12345\n  organic: kept`,
+      )
+
+      expect(config.messages.automation).toBe('')
+      expect(config.messages.organic).toBe('kept')
+    })
+  })
+
+  describe('labels', () => {
+    it('accepts a custom label', () => {
+      expect(
+        parseRepoConfig('labels:\n  mixed: needs-review').labels.mixed,
+      ).toBe('needs-review')
+    })
+
+    it.each([
+      ['empty', '""'],
+      ['over 50 characters', `"${'x'.repeat(51)}"`],
+      ['not a string', '42'],
+    ])('falls back for a label that is %s', (_label, value) => {
+      expect(parseRepoConfig(`labels:\n  mixed: ${value}`).labels.mixed).toBe(
+        DEFAULT_CONFIG.labels.mixed,
+      )
+    })
+  })
+
+  it('does not let a config pollute Object.prototype', () => {
+    parseRepoConfig('__proto__:\n  polluted: true')
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
+})

--- a/server/api/webhook/github/_config.ts
+++ b/server/api/webhook/github/_config.ts
@@ -1,94 +1,128 @@
-import type { IdentityClassification } from '@unveil/identity'
+import * as v from 'valibot'
 import { parse as parseYaml } from 'yaml'
-
-export type ScanMode = 'full' | 'labels' | 'comment' | 'silent'
-
-export type AuthorAssociation =
-  | 'collaborator'
-  | 'contributor'
-  | 'first_timer'
-  | 'first_time_contributor'
-  | 'member'
-  | 'owner'
 
 export const SUPPORTED_CONFIG_VERSION = 1
 
-export type RepoConfig = {
-  version: number
-  'allowed-users': string[]
-  'trusted-author-associations': AuthorAssociation[]
-  'auto-close': boolean
-  'auto-close-classifications': IdentityClassification[]
-  honeypot: boolean
-  mode: ScanMode
-  'comment-on-organic': boolean
-  scan: {
-    'pull-requests': boolean
-    issues: boolean
-  }
-  labels: {
-    'community-flagged': string
-    mixed: string
-    automation: string
-  }
-  messages: {
-    organic: string
-    mixed: string
-    automation: string
-    'insufficient-data': string
-    'community-flagged': string
+/** GitHub rejects a label name longer than this. */
+const MAX_LABEL_LENGTH = 50
+
+/**
+ * A custom message is posted as a comment under this app's name, so it is
+ * capped rather than passed through at whatever length the file carries.
+ */
+export const MAX_MESSAGE_LENGTH = 2_000
+
+const CLASSIFICATIONS = [
+  'organic',
+  'mixed',
+  'automation',
+  'insufficient-data',
+] as const
+
+const AUTHOR_ASSOCIATIONS = [
+  'collaborator',
+  'contributor',
+  'first_timer',
+  'first_time_contributor',
+  'member',
+  'owner',
+] as const
+
+const MODES = ['full', 'labels', 'comment', 'silent'] as const
+
+export type ScanMode = (typeof MODES)[number]
+export type AuthorAssociation = (typeof AUTHOR_ASSOCIATIONS)[number]
+
+const flag = (value: boolean) => v.fallback(v.boolean(), value)
+
+const message = () =>
+  v.fallback(v.pipe(v.string(), v.maxLength(MAX_MESSAGE_LENGTH)), '')
+
+const label = (name: string) =>
+  v.fallback(
+    v.pipe(v.string(), v.nonEmpty(), v.maxLength(MAX_LABEL_LENGTH)),
+    name,
+  )
+
+function section<const TEntries extends v.ObjectEntries>(entries: TEntries) {
+  const schema = v.object(entries)
+
+  return v.fallback(schema, v.parse(schema, {}))
+}
+
+const RepoConfigSchema = v.object({
+  version: v.fallback(
+    v.pipe(v.number(), v.integer()),
+    SUPPORTED_CONFIG_VERSION,
+  ),
+  'allowed-users': v.fallback(v.array(v.string()), []),
+  'trusted-author-associations': v.fallback(
+    v.array(v.picklist(AUTHOR_ASSOCIATIONS)),
+    [],
+  ),
+  'auto-close': flag(false),
+  'auto-close-classifications': v.fallback(
+    v.array(v.picklist(CLASSIFICATIONS)),
+    ['automation'],
+  ),
+  honeypot: flag(false),
+  mode: v.fallback(v.picklist(MODES), 'full'),
+  'comment-on-organic': flag(false),
+  scan: section({
+    'pull-requests': flag(true),
+    issues: flag(false),
+  }),
+  labels: section({
+    'community-flagged': label('agentscan:community-flagged'),
+    mixed: label('agentscan:mixed-signals'),
+    automation: label('agentscan:automation-signals'),
+  }),
+  messages: section({
+    organic: message(),
+    mixed: message(),
+    automation: message(),
+    'insufficient-data': message(),
+    'community-flagged': message(),
     /**
      * Replaces the visible greeting of the honeypot comment. The hidden
      * verification block is always appended. It is what the trap is made of.
      * Supports `{username}` and `{type}` placeholders.
      */
-    honeypot: string
+    honeypot: message(),
     /**
      * Same, but for authors GitHub reports as opening their first PR/issue on
      * the repository. Falls back to `honeypot` when left blank, so a repo that
      * only customises the regular greeting keeps one voice.
      */
-    'honeypot-first-time': string
-  }
-}
+    'honeypot-first-time': message(),
+  }),
+})
 
-export const DEFAULT_CONFIG: RepoConfig = {
-  version: SUPPORTED_CONFIG_VERSION,
-  'allowed-users': [],
-  'trusted-author-associations': [],
-  'auto-close': false,
-  'auto-close-classifications': ['automation'],
-  honeypot: false,
-  mode: 'full',
-  'comment-on-organic': false,
-  scan: {
-    'pull-requests': true,
-    issues: false,
-  },
-  labels: {
-    'community-flagged': 'agentscan:community-flagged',
-    mixed: 'agentscan:mixed-signals',
-    automation: 'agentscan:automation-signals',
-  },
-  messages: {
-    organic: '',
-    mixed: '',
-    automation: '',
-    'community-flagged': '',
-    'insufficient-data': '',
-    honeypot: '',
-    'honeypot-first-time': '',
-  },
-}
+export type RepoConfig = v.InferOutput<typeof RepoConfigSchema>
+
+/** Every field falls back, so the schema's own output is the default config. */
+export const DEFAULT_CONFIG: RepoConfig = v.parse(RepoConfigSchema, {})
 
 export function parseRepoConfig(yamlContent: string): RepoConfig {
-  const raw = parseYaml(yamlContent) as Partial<RepoConfig> | null
+  let raw: unknown
+
+  try {
+    raw = parseYaml(yamlContent)
+  } catch (err) {
+    console.warn('[agentscan] agentscan.yml is not valid YAML:', err)
+    return DEFAULT_CONFIG
+  }
 
   if (raw == null) {
     return DEFAULT_CONFIG
   }
 
-  const version = raw.version ?? SUPPORTED_CONFIG_VERSION
+  // Read before validation: an unsupported version means the keys below may not
+  // mean what this schema thinks they mean
+  const version = v.parse(
+    v.fallback(v.pipe(v.number(), v.integer()), SUPPORTED_CONFIG_VERSION),
+    (raw as { version?: unknown })?.version,
+  )
 
   if (version > SUPPORTED_CONFIG_VERSION) {
     console.warn(
@@ -97,12 +131,14 @@ export function parseRepoConfig(yamlContent: string): RepoConfig {
     return DEFAULT_CONFIG
   }
 
-  return {
-    ...DEFAULT_CONFIG,
-    ...raw,
-    version,
-    scan: { ...DEFAULT_CONFIG.scan, ...raw.scan },
-    labels: { ...DEFAULT_CONFIG.labels, ...raw.labels },
-    messages: { ...DEFAULT_CONFIG.messages, ...raw.messages },
+  const result = v.safeParse(RepoConfigSchema, raw)
+
+  if (!result.success) {
+    console.warn(
+      '[agentscan] agentscan.yml is not a mapping. Falling back to defaults.',
+    )
+    return DEFAULT_CONFIG
   }
+
+  return result.output
 }

--- a/shared/utils/parse-repo-slug.test.ts
+++ b/shared/utils/parse-repo-slug.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { parseRepoSlug } from './parse-repo-slug'
+
+describe('parseRepoSlug', () => {
+  it('parses a bare slug', () => {
+    expect(parseRepoSlug('vuejs/core')).toEqual({
+      owner: 'vuejs',
+      repo: 'core',
+      path: 'vuejs/core',
+    })
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(parseRepoSlug('  vuejs/core  ')?.path).toBe('vuejs/core')
+  })
+
+  it('accepts a trailing slash', () => {
+    expect(parseRepoSlug('vuejs/core/')?.path).toBe('vuejs/core')
+  })
+
+  it.each([
+    'https://github.com/vuejs/core',
+    'http://github.com/vuejs/core',
+    'https://www.github.com/vuejs/core',
+    'github.com/vuejs/core',
+    'www.github.com/vuejs/core',
+    'https://github.com/vuejs/core.git',
+  ])('parses %s', (input) => {
+    expect(parseRepoSlug(input)?.path).toBe('vuejs/core')
+  })
+
+  it('drops the query string and fragment', () => {
+    expect(
+      parseRepoSlug('https://github.com/vuejs/core?tab=readme#install')?.path,
+    ).toBe('vuejs/core')
+  })
+
+  // Reading from the end would scan `pull/123` as if it were a repository.
+  it('reads the repository from a deep link, not its trailing path', () => {
+    expect(parseRepoSlug('https://github.com/vuejs/core/pull/123')?.path).toBe(
+      'vuejs/core',
+    )
+    expect(parseRepoSlug('vuejs/core/issues/9/comments')?.path).toBe(
+      'vuejs/core',
+    )
+  })
+
+  it('preserves case, so the caller decides how to normalize it', () => {
+    expect(parseRepoSlug('MatteoGabriele/AgentScan')).toEqual({
+      owner: 'MatteoGabriele',
+      repo: 'AgentScan',
+      path: 'MatteoGabriele/AgentScan',
+    })
+  })
+
+  it('accepts the punctuation GitHub allows in a repository name', () => {
+    expect(parseRepoSlug('octocat/.github')?.repo).toBe('.github')
+    expect(parseRepoSlug('octocat/my_repo.js-2')?.repo).toBe('my_repo.js-2')
+  })
+
+  it.each([
+    ['empty', ''],
+    ['whitespace only', '   '],
+    ['no separator', 'vuejs'],
+    ['owner only', 'vuejs/'],
+    ['repo only', '/core'],
+  ])('rejects %s', (_label, input) => {
+    expect(parseRepoSlug(input)).toBeNull()
+  })
+
+  // Each of these used to be accepted and spent a GitHub request to 404.
+  it.each([
+    ['a space in the owner', 'vue js/core'],
+    ['a leading hyphen', '-vuejs/core'],
+    ['a trailing hyphen', 'vuejs-/core'],
+    ['consecutive hyphens', 'vue--js/core'],
+    ['an owner over 39 characters', `${'a'.repeat(40)}/core`],
+    ['a repo over 100 characters', `vuejs/${'a'.repeat(101)}`],
+    ['punctuation GitHub does not allow', 'vuejs/co~re'],
+    ['a traversal segment', 'vuejs/..'],
+    ['a single dot repo', 'vuejs/.'],
+  ])('rejects %s', (_label, input) => {
+    expect(parseRepoSlug(input)).toBeNull()
+  })
+
+  // Reading the last two segments turned any forge's URL into a GitHub scan of
+  // a same-named repository.
+  it('rejects a URL from another host', () => {
+    expect(parseRepoSlug('https://gitlab.com/vuejs/core')).toBeNull()
+    expect(parseRepoSlug('https://evil.example/vuejs/core')).toBeNull()
+  })
+
+  it('rejects a traversal-shaped path', () => {
+    expect(parseRepoSlug('../../vuejs/core')).toBeNull()
+  })
+})

--- a/shared/utils/parse-repo-slug.ts
+++ b/shared/utils/parse-repo-slug.ts
@@ -4,18 +4,55 @@ type ParseRepoSlugReturn = {
   path: string
 } | null
 
-export function parseRepoSlug(input: string): ParseRepoSlugReturn {
-  const slugMatch = input.trim().split('/')
-  const owner = slugMatch?.[slugMatch.length - 2]
-  const repo = slugMatch?.[slugMatch.length - 1]
+/**
+ * GitHub logins: alphanumerics and single internal hyphens, 39 characters max.
+ * A leading, trailing or doubled hyphen is not a login.
+ */
+const OWNER_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/
 
-  if (owner && repo) {
-    return {
-      owner,
-      repo,
-      path: `${owner}/${repo}`,
-    }
+/** Repository names: alphanumerics plus `-`, `_` and `.`, 100 characters max. */
+const REPO_PATTERN = /^[A-Za-z0-9._-]{1,100}$/
+
+/**
+ * Turns whatever a contributor pasted into an `owner/repo` pair, or null.
+ */
+export function parseRepoSlug(input: string): ParseRepoSlugReturn {
+  const trimmed = input.trim()
+
+  if (!trimmed) {
+    return null
   }
 
-  return null
+  // Only github.com is stripped.
+  const withoutOrigin = trimmed
+    .replace(/^[A-Za-z][A-Za-z0-9+.-]*:\/\//, '')
+    .replace(/^(?:www\.)?github\.com\//i, '')
+
+  const [pathname = ''] = withoutOrigin.split(/[?#]/)
+
+  // First two segments, not the last two: `owner/repo/pull/123` is a link to a
+  // pull request in `owner/repo`, and reading it from the end scans `pull/123`.
+  const [owner, rawRepo] = pathname.split('/').filter(Boolean)
+
+  if (!owner || !rawRepo) {
+    return null
+  }
+
+  // GitHub rejects repository names ending in `.git`, so the suffix is only ever
+  // the tail of a clone URL.
+  const repo = rawRepo.replace(/\.git$/i, '')
+
+  if (!OWNER_PATTERN.test(owner) || !REPO_PATTERN.test(repo)) {
+    return null
+  }
+
+  if (repo === '.' || repo === '..') {
+    return null
+  }
+
+  return {
+    owner,
+    repo,
+    path: `${owner}/${repo}`,
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Scan results are cached for up to 10 minutes, improving response times for repeated requests.
  * Scans avoid repeating analysis for the same contributor.

* **Bug Fixes**
  * Repository inputs now reliably support GitHub URLs, query strings, fragments, and trailing paths.
  * Invalid repository references are rejected more consistently.

* **Configuration**
  * Webhook repository settings now validate supported values and safely fall back to defaults for invalid or unsupported configuration files.
  * Configuration labels and messages are subject to length limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->