### PR TITLE
feat(lab): add weeks ridgeline chart

### DIFF
--- a/app/components/Activity/ClassificationToggle.vue
+++ b/app/components/Activity/ClassificationToggle.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import type { IdentityClassification } from '@unveil/identity'
+import { computed } from 'vue'
+
+const props = defineProps<{
+  withInsufficientData?: boolean
+}>()
+
+const selected = defineModel<IdentityClassification>()
+
+const options = computed(() => [
+  {
+    value: 'organic',
+    label: 'Organic',
+  },
+  {
+    value: 'mixed',
+    label: 'Mixed',
+  },
+  {
+    value: 'automation',
+    label: 'Automation',
+  },
+  ...(props.withInsufficientData
+    ? [
+        {
+          value: 'insufficient-data',
+          label: 'Insufficient data',
+        },
+      ]
+    : []),
+])
+</script>
+
+<template>
+  <Toggle :options="options" v-model="selected" />
+</template>

--- a/app/components/Activity/ClassificationToggle.vue
+++ b/app/components/Activity/ClassificationToggle.vue
@@ -2,10 +2,6 @@
 import type { IdentityClassification } from '@unveil/identity'
 import { computed } from 'vue'
 
-const props = defineProps<{
-  withInsufficientData?: boolean
-}>()
-
 const selected = defineModel<IdentityClassification>()
 
 const options = computed(() => [
@@ -21,14 +17,6 @@ const options = computed(() => [
     value: 'automation',
     label: 'Automation',
   },
-  ...(props.withInsufficientData
-    ? [
-        {
-          value: 'insufficient-data',
-          label: 'Insufficient data',
-        },
-      ]
-    : []),
 ])
 </script>
 

--- a/app/components/Activity/ClassificationToggle.vue
+++ b/app/components/Activity/ClassificationToggle.vue
@@ -33,5 +33,5 @@ const options = computed(() => [
 </script>
 
 <template>
-  <Toggle :options="options" v-model="selected" />
+  <Toggle v-model="selected" :options="options" />
 </template>

--- a/app/components/Chart/GlobalEventsRidgeline.vue
+++ b/app/components/Chart/GlobalEventsRidgeline.vue
@@ -1,0 +1,165 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import dayjs, { type Dayjs } from 'dayjs'
+import isoWeek from 'dayjs/plugin/isoWeek'
+import utc from 'dayjs/plugin/utc'
+import {
+  VueUiRidgeline,
+  type VueUiRidgelineConfig,
+  type VueUiRidgelineDatasetItem,
+} from 'vue-data-ui/vue-ui-ridgeline'
+import { CLASSIFICATIONS_WITH_NAME_AND_CATEGORY } from '~~/shared/utils/charts.ts'
+
+import 'vue-data-ui/style.css'
+import ClassificationToggle from '../Activity/ClassificationToggle.vue'
+import type { IdentityClassification } from '@unveil/identity'
+
+dayjs.extend(isoWeek)
+dayjs.extend(utc)
+
+const { data: activity } = useActivity()
+
+const rootEl = shallowRef<HTMLElement | null>(null)
+
+onMounted(() => {
+  rootEl.value = document.documentElement
+})
+
+const colors = useColors(rootEl)
+
+const dates = computed(() => activity.value?.dates)
+const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const countsByDate = computed(() => activity.value?.countsByDate)
+const selectedClassification = ref<IdentityClassification>('organic')
+
+const dataset = computed<VueUiRidgelineDatasetItem[]>(() => {
+  const classification = CLASSIFICATIONS_WITH_NAME_AND_CATEGORY.find(
+    ({ category }) => category === selectedClassification.value,
+  )
+
+  if (!classification) {
+    return []
+  }
+
+  const weeks = new Map<
+    string,
+    {
+      monday: Dayjs
+      percentages: Map<number, number>
+    }
+  >()
+
+  for (const scanTime of dates.value ?? []) {
+    const date = dayjs.utc(scanTime)
+
+    if (!date.isValid()) {
+      continue
+    }
+
+    const weekdayIndex = date.isoWeekday() - 1
+    const monday = date.startOf('isoWeek')
+    const weekKey = monday.format('YYYY-MM-DD')
+    const week = weeks.get(weekKey) ?? {
+      monday,
+      percentages: new Map<number, number>(),
+    }
+
+    week.percentages.set(
+      weekdayIndex,
+      countsByDate.value?.[scanTime]?.[classification.category].percentage ?? 0,
+    )
+
+    weeks.set(weekKey, week)
+  }
+
+  return [...weeks.values()]
+    .filter(({ percentages }) => percentages.size === WEEKDAYS.length)
+    .sort((a, b) => a.monday.valueOf() - b.monday.valueOf())
+    .map(({ monday, percentages }) => ({
+      name: `${monday.format('YYYY-MM-DD')} - ${monday.add(6, 'day').format('YYYY-MM-DD')}`,
+      datapoints: [
+        {
+          name: classification.name,
+          values: WEEKDAYS.map((_, index) => percentages.get(index) ?? 0),
+          color: colors.value[classification.category],
+        },
+      ],
+    }))
+})
+
+const config = computed<VueUiRidgelineConfig>(() => ({
+  userOptions: { show: false },
+  style: {
+    chart: {
+      areas: {
+        height: 60,
+        rowHeight: 30,
+        maxPoint: {
+          adaptStrokeToBackground: false,
+          stroke: colors.value.bg,
+          strokeDasharray: 2,
+        },
+        stroke: {
+          useSerieColor: true,
+        },
+      },
+      backgroundColor: colors.value.bg,
+      legend: { show: false },
+      dialog: { show: false },
+      padding: {
+        top: 0,
+        left: 0,
+      },
+      selector: {
+        stroke: colors.value.bg,
+        strokeDasharray: 0,
+        dot: {
+          radius: 3,
+          stroke: colors.value.bg,
+        },
+        labels: {
+          color: colors.value.text,
+          fontSize: 10,
+          formatter: ({ value }) => {
+            return `${Math.round(value)}%`
+          },
+        },
+      },
+      xAxis: {
+        labels: {
+          values: WEEKDAYS,
+          color: colors.value.textMuted,
+          fontSize: 10,
+          offsetY: -12,
+        },
+      },
+      yAxis: {
+        labels: {
+          fontSize: 6.5,
+          color: colors.value.textMuted,
+          centered: true,
+        },
+      },
+      zeroLine: { show: false },
+    },
+  },
+}))
+</script>
+
+<template>
+  <div>
+    <div class="mb-5">
+      <h2 class="text-center">Trends by week days</h2>
+      <p class="text-sm text-ui-muted text-center">
+        Daily ecosystem activity evolution split by weeks
+      </p>
+    </div>
+    <div class="my-6 flex justify-center">
+      <ClassificationToggle v-model="selectedClassification" />
+    </div>
+    <ClientOnly>
+      <VueUiRidgeline :dataset :config> </VueUiRidgeline>
+    </ClientOnly>
+  </div>
+</template>

--- a/app/components/Chart/GlobalEventsRidgeline.vue
+++ b/app/components/Chart/GlobalEventsRidgeline.vue
@@ -67,7 +67,8 @@ const dataset = computed<VueUiRidgelineDatasetItem[]>(() => {
 
     week.percentages.set(
       weekdayIndex,
-      countsByDate.value?.[scanTime]?.[classification.category].percentage ?? 0,
+      countsByDate.value?.[scanTime]?.[classification.category]?.percentage ??
+        0,
     )
 
     weeks.set(weekKey, week)

--- a/app/pages/lab.vue
+++ b/app/pages/lab.vue
@@ -41,6 +41,9 @@
         <LazyChartScoreDistribution hydrate-on-visible />
       </div>
       <div class="w-full">
+        <LazyChartGlobalEventsRidgeline hydrate-on-visible />
+      </div>
+      <div class="w-full">
         <LazyReportWeeklyClassification
           :hydrate-on-visible="{ rootMargin: '0px 0px 600px 0px' }"
         />

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.4.2",
     "vue": "^3.5.28",
-    "vue-data-ui": "^3.25.4",
+    "vue-data-ui": "^3.25.5",
     "vue-router": "^4.6.4",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.5.28
         version: 3.5.35(typescript@6.0.3)
       vue-data-ui:
-        specifier: ^3.25.4
-        version: 3.25.4(vue@3.5.35(typescript@6.0.3))
+        specifier: ^3.25.5
+        version: 3.25.5(vue@3.5.35(typescript@6.0.3))
       vue-router:
         specifier: ^4.6.4
         version: 4.6.4(vue@3.5.35(typescript@6.0.3))
@@ -6422,8 +6422,8 @@ packages:
   vue-component-type-helpers@3.3.11:
     resolution: {integrity: sha512-LwcxzeliO9fkQcpJG0PoX8X5kmAhKmH9wkpDLxNabwzkQ9Zeib2YVHwFV4pcWmMLfXVfjr/dSV+DaJ3cIPgSNA==}
 
-  vue-data-ui@3.25.4:
-    resolution: {integrity: sha512-fJExip0mhLeNagZzd9gz7wUN1aIR7CoE6iQAKppwBIlm92yisUPqytP5d2mbJK23R3vwObABIjfuSyimVP3Mlw==}
+  vue-data-ui@3.25.5:
+    resolution: {integrity: sha512-R+b6ejdPBVftZzk3q1HWyrfWi6D42K6F7iBoarnb35yZWbmlHaRSA5NI1Tp034BQtn+Q39SGAjY0rJa0lvA5hg==}
     peerDependencies:
       jspdf: '>=3.0.1'
       vue: '>=3.3.0'
@@ -13764,7 +13764,7 @@ snapshots:
 
   vue-component-type-helpers@3.3.11: {}
 
-  vue-data-ui@3.25.4(vue@3.5.35(typescript@6.0.3)):
+  vue-data-ui@3.25.5(vue@3.5.35(typescript@6.0.3)):
     dependencies:
       vue: 3.5.35(typescript@6.0.3)
 


### PR DESCRIPTION
This adds a ridgeline chart in the lab, to attempt highlighting patterns in week days activity.

https://github.com/user-attachments/assets/1fc19a53-25de-4e91-8211-e99d67f33590



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global events ridgeline chart to visualize weekly daily activity percentages by identity classification.
  - Added classification controls for organic, mixed, automation, and optionally insufficient-data activity.
  - Displayed the new chart on the Lab page with visibility-based loading.

- **Chores**
  - Updated the charting library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->